### PR TITLE
fix: 修复 Web 端缺失密码填写入口和部分适配器出现"注册指令报错"的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 <!-- markdownlint-disable MD041 -->
 # ChangeLog
 
+# 2026/04/02 v1.2.2
+
+## 🚀 What's Changed
+
+### 🐛 Bug Fixes (修复)
+
+- 修复了在 Telegram 适配器下，插件启动时可能因内部事件模块被重复扫描/注册而触发“注册指令报错”的问题 by @DBJD-CR in #52
+- 修复了配置密码的情况下，Web 端缺失密码填写入口的问题 by @DBJD-CR in #52
+
+---
+
+**Full Changelog**: https://github.com/DBJD-CR/astrbot_plugin_proactive_chat/compare/v1.2.1...v1.2.2
+
+---
+
 # 2026/04/01 v1.2.1
 
 ## 🚀 What's Changed

--- a/admin/css/style.css
+++ b/admin/css/style.css
@@ -336,6 +336,82 @@ body.dark-theme .boot-loader__progress-bar {
     100% { transform: translate3d(220%, 0, 0) scaleX(0.35); }
 }
 
+.boot-login {
+    display: none;
+    width: min(360px, calc(100vw - 48px));
+    margin: 16px auto 0;
+    text-align: left;
+}
+
+.boot-login__label {
+    display: block;
+    margin-bottom: 8px;
+    font-size: 13px;
+    color: #625B71;
+}
+
+.boot-login__input {
+    width: 100%;
+    box-sizing: border-box;
+    height: 44px;
+    padding: 0 14px;
+    border: 1px solid rgba(103, 80, 164, 0.22);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.88);
+    color: #1C1B1F;
+    outline: none;
+    font-size: 14px;
+    box-shadow: 0 8px 24px rgba(103, 80, 164, 0.08);
+}
+
+.boot-login__input:focus {
+    border-color: rgba(103, 80, 164, 0.5);
+    box-shadow: 0 0 0 3px rgba(103, 80, 164, 0.12), 0 8px 24px rgba(103, 80, 164, 0.08);
+}
+
+.boot-login__button {
+    width: 100%;
+    margin-top: 12px;
+    height: 44px;
+    border: none;
+    border-radius: 14px;
+    background: linear-gradient(135deg, #7F67BE 0%, #6750A4 100%);
+    color: #fff;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 10px 24px rgba(103, 80, 164, 0.22);
+}
+
+.boot-login__button:disabled {
+    cursor: not-allowed;
+}
+
+html.theme-dark .boot-login__label,
+body.dark-theme .boot-login__label {
+    color: #CAC4D0;
+}
+
+html.theme-dark .boot-login__input,
+body.dark-theme .boot-login__input {
+    background: rgba(28, 27, 31, 0.88);
+    color: #E6E1E5;
+    border-color: rgba(208, 188, 255, 0.22);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.24);
+}
+
+html.theme-dark .boot-login__input:focus,
+body.dark-theme .boot-login__input:focus {
+    border-color: rgba(208, 188, 255, 0.48);
+    box-shadow: 0 0 0 3px rgba(208, 188, 255, 0.16), 0 8px 24px rgba(0, 0, 0, 0.24);
+}
+
+html.theme-dark .boot-login__button,
+body.dark-theme .boot-login__button {
+    background: linear-gradient(135deg, #A58CFF 0%, #7F67BE 100%);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.28);
+}
+
 /* ===== 通用材质与布局骨架 ===== */
 /* 磨砂玻璃效果 */
 .glass {

--- a/admin/index.html
+++ b/admin/index.html
@@ -37,12 +37,10 @@
         </div>
         <div class="boot-loader__title">主动消息管理端</div>
         <div class="boot-loader__subtitle" id="boot-text">正在初始化...</div>
-        <div id="boot-login" style="display:none; width:min(360px, calc(100vw - 48px)); margin:16px auto 0; text-align:left;">
-            <label for="boot-password" style="display:block; margin-bottom:8px; font-size:13px; color:#625B71;">管理端密码</label>
-            <input id="boot-password" type="password" autocomplete="current-password" placeholder="请输入访问密码"
-                style="width:100%; box-sizing:border-box; height:44px; padding:0 14px; border:1px solid rgba(103,80,164,0.22); border-radius:14px; background:rgba(255,255,255,0.88); color:#1C1B1F; outline:none; font-size:14px; box-shadow:0 8px 24px rgba(103,80,164,0.08);">
-            <button id="boot-login-button" type="button"
-                style="width:100%; margin-top:12px; height:44px; border:none; border-radius:14px; background:linear-gradient(135deg, #7F67BE 0%, #6750A4 100%); color:#fff; font-size:14px; font-weight:600; cursor:pointer; box-shadow:0 10px 24px rgba(103,80,164,0.22);">
+        <div id="boot-login" class="boot-login">
+            <label for="boot-password" class="boot-login__label">管理端密码</label>
+            <input id="boot-password" class="boot-login__input" type="password" autocomplete="current-password" placeholder="请输入访问密码">
+            <button id="boot-login-button" class="boot-login__button" type="button">
                 登录进入
             </button>
         </div>
@@ -64,6 +62,8 @@
         (function () {
             // 该标记用于阻止 React 应用过早启动，直到鉴权探测流程结束后再解除。
             window.__PROACTIVE_AUTH_PENDING = true;
+
+            var bootLoginEventsBound = false;
 
             function proceed() {
                 // 告知其余脚本：鉴权检查已完成，可以开始渲染业务界面。
@@ -92,7 +92,7 @@
             }
 
             function showInfo(msg) {
-                var text = document.getElementById('boot-text');
+                const text = document.getElementById('boot-text');
                 if (text) {
                     text.textContent = msg;
                     text.style.color = '#D05F00';
@@ -120,7 +120,7 @@
                 if (message) showError(message);
                 setLoginBusy(false);
 
-                if (!button || !input || button.__bootBound) {
+                if (!button || !input) {
                     if (input) setTimeout(function () { input.focus(); }, 0);
                     return;
                 }
@@ -143,9 +143,13 @@
                         body: JSON.stringify({ password: password }),
                     })
                         .then(function (res) {
-                            return res.json().catch(function () { return null; }).then(function (data) {
-                                return { ok: res.ok, data: data };
-                            });
+                            return res.json()
+                                .then(function (data) {
+                                    return { ok: res.ok, data: data };
+                                })
+                                .catch(function () {
+                                    return { ok: res.ok, data: null };
+                                });
                         })
                         .then(function (result) {
                             if (!result.ok) {
@@ -167,14 +171,16 @@
                         });
                 }
 
-                button.addEventListener('click', submitLogin);
-                input.addEventListener('keydown', function (event) {
-                    if (event.key === 'Enter') {
-                        event.preventDefault();
-                        submitLogin();
-                    }
-                });
-                button.__bootBound = true;
+                if (!bootLoginEventsBound) {
+                    button.addEventListener('click', submitLogin);
+                    input.addEventListener('keydown', function (event) {
+                        if (event.key === 'Enter') {
+                            event.preventDefault();
+                            submitLogin();
+                        }
+                    });
+                    bootLoginEventsBound = true;
+                }
                 setTimeout(function () { input.focus(); }, 0);
             }
 
@@ -190,6 +196,9 @@
                         window.AuthUtil.clearToken();
                         showLoginForm('访问令牌已失效，请重新登录');
                         return;
+                    }
+                    if (!res.ok) {
+                        throw new Error('管理端鉴权校验失败，请稍后重试');
                     }
                     proceed();
                 });

--- a/admin/index.html
+++ b/admin/index.html
@@ -37,6 +37,15 @@
         </div>
         <div class="boot-loader__title">主动消息管理端</div>
         <div class="boot-loader__subtitle" id="boot-text">正在初始化...</div>
+        <div id="boot-login" style="display:none; width:min(360px, calc(100vw - 48px)); margin:16px auto 0; text-align:left;">
+            <label for="boot-password" style="display:block; margin-bottom:8px; font-size:13px; color:#625B71;">管理端密码</label>
+            <input id="boot-password" type="password" autocomplete="current-password" placeholder="请输入访问密码"
+                style="width:100%; box-sizing:border-box; height:44px; padding:0 14px; border:1px solid rgba(103,80,164,0.22); border-radius:14px; background:rgba(255,255,255,0.88); color:#1C1B1F; outline:none; font-size:14px; box-shadow:0 8px 24px rgba(103,80,164,0.08);">
+            <button id="boot-login-button" type="button"
+                style="width:100%; margin-top:12px; height:44px; border:none; border-radius:14px; background:linear-gradient(135deg, #7F67BE 0%, #6750A4 100%); color:#fff; font-size:14px; font-weight:600; cursor:pointer; box-shadow:0 10px 24px rgba(103,80,164,0.22);">
+                登录进入
+            </button>
+        </div>
         <div class="boot-loader__progress">
             <div class="boot-loader__progress-bar"></div>
         </div>
@@ -82,6 +91,110 @@
                 }
             }
 
+            function showInfo(msg) {
+                var text = document.getElementById('boot-text');
+                if (text) {
+                    text.textContent = msg;
+                    text.style.color = '#D05F00';
+                }
+            }
+
+            function setLoginBusy(busy) {
+                var button = document.getElementById('boot-login-button');
+                var input = document.getElementById('boot-password');
+                if (button) {
+                    button.disabled = !!busy;
+                    button.style.opacity = busy ? '0.72' : '1';
+                    button.textContent = busy ? '登录中...' : '登录进入';
+                }
+                if (input) {
+                    input.disabled = !!busy;
+                }
+            }
+
+            function showLoginForm(message) {
+                var login = document.getElementById('boot-login');
+                var input = document.getElementById('boot-password');
+                var button = document.getElementById('boot-login-button');
+                if (login) login.style.display = 'block';
+                if (message) showError(message);
+                setLoginBusy(false);
+
+                if (!button || !input || button.__bootBound) {
+                    if (input) setTimeout(function () { input.focus(); }, 0);
+                    return;
+                }
+
+                function submitLogin() {
+                    var password = input.value || '';
+                    if (!password.trim()) {
+                        showError('请输入管理端密码');
+                        input.focus();
+                        return;
+                    }
+
+                    setLoginBusy(true);
+                    showInfo('正在验证密码...');
+                    fetch('/api/login', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify({ password: password }),
+                    })
+                        .then(function (res) {
+                            return res.json().catch(function () { return null; }).then(function (data) {
+                                return { ok: res.ok, data: data };
+                            });
+                        })
+                        .then(function (result) {
+                            if (!result.ok) {
+                                var errorMessage = result.data && result.data.error ? result.data.error : '登录失败';
+                                throw new Error(errorMessage);
+                            }
+                            var token = result.data && result.data.token;
+                            if (!token) {
+                                throw new Error('登录成功但未获取到访问令牌');
+                            }
+                            window.AuthUtil.setToken(token);
+                            proceed();
+                        })
+                        .catch(function (err) {
+                            showError(err && err.message ? err.message : '登录失败，请稍后重试');
+                            setLoginBusy(false);
+                            input.focus();
+                            input.select();
+                        });
+                }
+
+                button.addEventListener('click', submitLogin);
+                input.addEventListener('keydown', function (event) {
+                    if (event.key === 'Enter') {
+                        event.preventDefault();
+                        submitLogin();
+                    }
+                });
+                button.__bootBound = true;
+                setTimeout(function () { input.focus(); }, 0);
+            }
+
+            function verifyExistingToken(token) {
+                // 通过访问受保护接口来验证 token 是否仍然有效。
+                return fetch('/api/status', {
+                    headers: {
+                        'Authorization': 'Bearer ' + token,
+                    },
+                }).then(function (res) {
+                    if (res.status === 401) {
+                        // 若 token 失效，则清理本地缓存，避免前端继续携带错误凭证。
+                        window.AuthUtil.clearToken();
+                        showLoginForm('访问令牌已失效，请重新登录');
+                        return;
+                    }
+                    proceed();
+                });
+            }
+
             // 第一步：询问后端当前是否启用了管理端密码。
             fetch('/api/auth-info')
                 .then(function (res) { return res.json(); })
@@ -95,24 +208,11 @@
                     // 已启用鉴权时，从 localStorage 中取出历史 token 进行有效性验证。
                     var token = window.AuthUtil.getToken();
                     if (!token) {
-                        showError('请先通过登录接口获取访问令牌');
+                        showLoginForm('请输入管理端密码以继续访问');
                         return;
                     }
 
-                    // 通过访问受保护接口来验证 token 是否仍然有效。
-                    return fetch('/api/status', {
-                        headers: {
-                            'Authorization': 'Bearer ' + token,
-                        },
-                    }).then(function (res) {
-                        if (res.status === 401) {
-                            // 若 token 失效，则清理本地缓存，避免前端继续携带错误凭证。
-                            window.AuthUtil.clearToken();
-                            showError('访问令牌已失效，请重新登录');
-                            return;
-                        }
-                        proceed();
-                    });
+                    return verifyExistingToken(token);
                 })
                 .catch(function () {
                     // 管理端不可达通常意味着后端服务未启动或网络异常。

--- a/admin/index.html
+++ b/admin/index.html
@@ -84,7 +84,7 @@
 
             function showError(msg) {
                 // 启动失败时直接在骨架屏上输出错误信息，避免用户只看到空白页。
-                var text = document.getElementById('boot-text');
+                const text = document.getElementById('boot-text');
                 if (text) {
                     text.textContent = msg;
                     text.style.color = '#B3261E';

--- a/core/message_events.py
+++ b/core/message_events.py
@@ -184,8 +184,10 @@ class EventsMixin:
         if normalized_session_id != session_id:
             await self._cancel_all_related_auto_triggers(normalized_session_id)
 
-        # 避免重复刷屏日志
+        # 读取当前会话配置，供日志与启用状态判断复用，避免重复查询。
         session_config = self._get_session_config(normalized_session_id)
+
+        # 避免重复刷屏日志
         if session_config and session_config.get("enable", False):
             if normalized_session_id not in self.first_message_logged:
                 self.first_message_logged.add(normalized_session_id)
@@ -194,7 +196,6 @@ class EventsMixin:
                 )
 
         # 未启用或配置无效则跳过
-        session_config = self._get_session_config(normalized_session_id)
         if not session_config or not session_config.get("enable", False):
             logger.debug(
                 f"[主动消息] {self._get_session_log_str(session_id, session_config)} 未启用或配置无效，跳过处理喵。"

--- a/core/message_events.py
+++ b/core/message_events.py
@@ -6,7 +6,7 @@ import time
 from typing import Any
 
 from astrbot.api import logger
-from astrbot.api.event import AstrMessageEvent, filter
+from astrbot.api.event import AstrMessageEvent
 
 
 class EventsMixin:
@@ -19,7 +19,6 @@ class EventsMixin:
     first_message_logged: set[str]
     scheduler: Any
 
-    @filter.event_message_type(filter.EventMessageType.PRIVATE_MESSAGE, priority=999)
     async def on_friend_message(self, event: AstrMessageEvent):
         """监听私聊消息，取消旧任务，并重置计时器和计数器。"""
         # 没有消息内容则无需处理
@@ -108,7 +107,6 @@ class EventsMixin:
             normalized_session_id, reset_counter=True
         )
 
-    @filter.event_message_type(filter.EventMessageType.GROUP_MESSAGE, priority=998)
     async def on_group_message(self, event: AstrMessageEvent):
         """监听群聊消息流，重置沉默倒计时，并取消已计划的主动消息任务。"""
         if not event.get_messages():
@@ -272,7 +270,6 @@ class EventsMixin:
             if changed:
                 await self._save_data_internal()
 
-    @filter.after_message_sent()
     async def on_after_message_sent(self, event: AstrMessageEvent):
         """监听 Bot 发送消息后事件，重置群聊沉默倒计时。"""
         session_id = event.unified_msg_origin

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: "astrbot_plugin_proactive_chat"
 display_name: "主动消息 (Proactive Chat)"
 author: "DBJD-CR & Gemini & Kimi & GPT"
-version: "v1.2.1"
+version: "v1.2.2"
 desc: "一个能让 Bot 在私聊和群聊中发起主动消息的插件，拥有上下文感知、持久化数据、动态情绪、免打扰时段和 TTS 集成。还有独立 WebUI，可进行个性化配置。"
 repo: "https://github.com/DBJD-CR/astrbot_plugin_proactive_chat"
 astrbot_version: ">=4.8.0"


### PR DESCRIPTION
## 📝 描述 / Description

fix #51 

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## 🛠️ 改动点 / Modifications

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.
<!-- 如果你的更改不是一个破坏性更改，请在检查框内打“x” -->
<!-- If your change is NOT a breaking change, please check the checkbox above (put an 'x' inside the brackets) -->

## 📸 运行截图或测试结果 / Screenshots or Test Results

<!--请粘贴截图、GIF 或测试日志，作为证据证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence to prove this change is effective.-->

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_proactive_chat/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_proactive_chat/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

修复 Web 管理界面中的身份验证问题，并解决某些适配器中的指令注册错误。

Bug 修复：
- 在 Web 管理页面中新增密码输入框和登录流程，使已配置的管理员密码可以直接在界面中输入并验证。
- 针对访问令牌过期或缺失的情况，显示登录表单而不是通用错误信息，从而在管理员认证失败时提供更好的恢复体验。
- 移除会导致某些适配器（如 Telegram）重复扫描/注册事件的消息事件过滤装饰器，避免出现“注册指令报错”的启动错误。

功能增强：
- 优化 Web 管理端启动界面，在进行身份验证检查时提供更清晰的状态和错误提示。

文档：
- 更新变更日志，新增 v1.2.2 条目，描述最新修复内容并链接到完整 diff。

杂务：
- 将插件版本元数据从 v1.2.1 升级为 v1.2.2。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix authentication issues in the Web admin UI and resolve command registration errors in certain adapters.

Bug Fixes:
- Add a password input and login flow to the Web admin page so that configured admin passwords can be entered and validated directly in the UI.
- Handle expired or missing access tokens by showing a login form instead of a generic error, improving recovery when admin authentication fails.
- Remove message event filter decorators that caused duplicate event scanning/registration in some adapters (e.g., Telegram), preventing the "注册指令报错" startup error.

Enhancements:
- Refine the Web admin boot screen with clearer status and error messaging during authentication checks.

Documentation:
- Update the changelog with a v1.2.2 entry describing the latest fixes and linking to the full diff.

Chores:
- Bump the plugin version metadata from v1.2.1 to v1.2.2.

</details>