### PR TITLE
fix: 修复配置热重载时 Web 管理端端口冲突拖垮 AstrBot

### DIFF
--- a/core/web_admin_server.py
+++ b/core/web_admin_server.py
@@ -1297,8 +1297,14 @@ class WebAdminServer:
         async def _serve():
             try:
                 await self.server.serve()
-            except Exception as e:
-                logger.error(f"[主动消息] Web 管理端运行异常喵: {e}")
+            except asyncio.CancelledError:
+                # 正常停止时会取消该任务，需放行以保持取消语义。
+                raise
+            except BaseException as e:
+                # Uvicorn 绑定端口失败会调用 sys.exit() 抛出 SystemExit（属
+                # BaseException 而非 Exception），若不在此拦截，该异常会作为未
+                # 检索的任务异常冒泡到事件循环根部，拖垮整个 AstrBot 进程。
+                logger.error(f"[主动消息] Web 管理端运行异常喵: {e!r}")
 
         self.server_task = asyncio.create_task(_serve())
 
@@ -1330,13 +1336,21 @@ class WebAdminServer:
         if self.server:
             # 通知 Uvicorn 进入优雅退出流程。
             self.server.should_exit = True
+            # 强制退出：避免存在未关闭的长连接（如 WebSocket）时优雅关闭
+            # 永久挂起，确保监听 socket 能被释放，防止热重载时端口冲突。
+            self.server.force_exit = True
 
         if self.server_task:
             try:
                 # 最多等待 5 秒，避免插件卸载时无限阻塞。
                 await asyncio.wait_for(self.server_task, timeout=5)
-            except Exception:
-                pass
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[主动消息] Web 管理端未在 5 秒内停止喵，端口可能仍被占用。"
+                )
+                self.server_task.cancel()
+            except Exception as e:
+                logger.warning(f"[主动消息] 停止 Web 管理端时出现异常喵: {e!r}")
 
         self._ws_connections.clear()
         logger.info("[主动消息] Web 管理端已停止喵。")

--- a/core/web_admin_server.py
+++ b/core/web_admin_server.py
@@ -1300,11 +1300,12 @@ class WebAdminServer:
             except asyncio.CancelledError:
                 # 正常停止时会取消该任务，需放行以保持取消语义。
                 raise
-            except BaseException as e:
+            except (SystemExit, Exception) as e:
                 # Uvicorn 绑定端口失败会调用 sys.exit() 抛出 SystemExit（属
                 # BaseException 而非 Exception），若不在此拦截，该异常会作为未
                 # 检索的任务异常冒泡到事件循环根部，拖垮整个 AstrBot 进程。
-                logger.error(f"[主动消息] Web 管理端运行异常喵: {e!r}")
+                # 这里显式只拦 SystemExit 与 Exception，不波及 KeyboardInterrupt。
+                logger.exception(f"[主动消息] Web 管理端运行异常喵: {e!r}")
 
         self.server_task = asyncio.create_task(_serve())
 
@@ -1346,9 +1347,15 @@ class WebAdminServer:
                 await asyncio.wait_for(self.server_task, timeout=5)
             except asyncio.TimeoutError:
                 logger.warning(
-                    "[主动消息] Web 管理端未在 5 秒内停止喵，端口可能仍被占用。"
+                    "[主动消息] Web 管理端未在 5 秒内停止喵，正在强制取消以释放端口。"
                 )
                 self.server_task.cancel()
+                # 等待取消真正完成，确保 stop 返回前监听 socket 已释放，
+                # 避免热重载时新实例绑定同端口失败。
+                try:
+                    await self.server_task
+                except (asyncio.CancelledError, Exception):
+                    pass
             except Exception as e:
                 logger.warning(f"[主动消息] 停止 Web 管理端时出现异常喵: {e!r}")
 


### PR DESCRIPTION
先占个坑，有其他的问题明日醒来再改。

## 📝 描述 / Description

fix #75：在 AstrBot 主面板（WebUI）保存本插件配置时，整个 AstrBot 进程崩溃。

根本原因是两个缺陷叠加，缺一不会崩：

1. **进程崩溃源**：保存插件配置会触发 AstrBot 热重载（串行执行 `terminate` → `initialize`）。`initialize` 时新实例会在 `4100` 端口重新启动内嵌的 Uvicorn 服务；若此时旧端口尚未释放，Uvicorn 绑定失败会调用 `sys.exit(1)` 抛出 `SystemExit`。但 `_serve()` 协程用 `except Exception` 捕获，而 `SystemExit` 继承自 `BaseException` 而非 `Exception`，因此捕获不到；又因为该协程是 `asyncio.create_task` 起的、从不被 `await`，异常便作为“未检索的任务异常”冒泡到事件循环根部（`run_until_complete`），最终拖垮整个 AstrBot 进程。这与 issue 报错日志里 `SystemExit: 1` 经由 `runners.py` → `_serve` 的调用栈完全吻合。

2. **端口冲突源**：`stop()` 仅设置 `should_exit = True`。当存在未关闭的长连接（如 WebUI 的 WebSocket）时，Uvicorn 的优雅关闭会一直等待连接断开而永久挂起，导致 `stop()` 里 `await asyncio.wait_for(..., timeout=5)` 必然超时；而超时异常又被 `except Exception: pass` 静默吞掉，旧监听 socket 始终没有释放。于是热重载时新实例绑定同端口必然失败。

## 🛠️ 改动点 / Modifications

仅修改 `core/web_admin_server.py` 一个文件（+18 / -4）：

- **`_serve()`**：`except Exception` 改为 `except BaseException`，拦住 Uvicorn 绑定失败抛出的 `SystemExit`，避免拖垮宿主进程；同时单独 `except asyncio.CancelledError: raise` 放行取消信号，保持正常停止时的取消语义。
- **`stop()`**：补充 `self.server.force_exit = True`，跳过对未关闭长连接的等待、确保监听 socket 被释放；并把超时分支由 `except Exception: pass` 改为记录告警并取消任务，不再静默忽略。

**影响 / Impact**：

- 保存配置触发热重载时，AstrBot 不再崩溃。
- 即便偶发端口未及时释放，最多导致本次 Web 管理端启动失败（仅 Web 端不可用，插件主体功能不受影响），而不会拖垮整个 AstrBot。
- `stop()` 现在能可靠释放端口，热重载后 Web 管理端可正常重启。
- 行为对既有用户无破坏：正常启动/停止流程不变，仅在异常路径上更健壮。

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.

## 📸 运行截图或测试结果 / Screenshots or Test Results

### 测试方法

由于崩溃的关键在于「`asyncio.create_task` 起的 `_serve` 任务、其内部的 except 层级、以及 `stop()` 的端口释放时序」，我们用一个独立脚本**按 1:1 复刻了 `start()`/`_serve()`/`stop()` 的真实结构**（相同的 `create_task` 且不 `await`、相同的 `except` 捕获层级、相同的 `should_exit` + `force_exit`），并搭配**真实的 Uvicorn（0.48.0）**运行，而非用 mock 假冒异常。

- **场景 A（复现并验证崩溃修复）**：先用一个 socket 抢占目标端口，再启动复刻的 server，使 Uvicorn 真实触发 `bind` 失败 → `sys.exit(1)` → `SystemExit`，观察进程是否还会被拖垮。
- **场景 B（验证端口释放）**：正常启动后调用复刻的 `stop()`，再探测端口是否已可重新绑定，验证 `force_exit` 是否真的释放了 socket。
- **场景 C（验证未引入回归）**：手动 `cancel()` 该任务，确认 `CancelledError` 仍能正常向上传播，没有被新的 `except BaseException` 误吞，从而不破坏正常卸载/重载的取消语义。

> 说明：这是针对崩溃机制的**结构级复现验证**，使用真实 Uvicorn 触发真实的 `SystemExit`；尚未在完整的 AstrBot + WebUI 桌面环境中做端到端点击复现，欢迎维护者在真实环境复测。

### 测试结果

```
[A] 端口被占时启动（模拟热重载抢端口）:
   [_serve] intercepted: SystemExit(1)        # 异常被 except BaseException 拦住
   -> 进程存活（未崩溃）: PASS
[B] 正常启动 -> stop -> 端口释放:
   启动后端口被占用: True
   stop 后端口已释放: True
   -> PASS
[C] CancelledError 放行（保持正常卸载语义）:
   -> CancelledError 正常传播: PASS
进程正常退出 —— SystemExit 未再拉崩事件循环。
```

对照实验（修复前的写法）：把 `_serve` 的捕获改回 `except Exception`，同一脚本下场景 A 即崩溃，`asyncio.run` 直接抛出 `SystemExit` 并打印 `Task exception was never retrieved`，与 issue #75 现象一致；改为 `except BaseException` 后进程存活。

## ✅ 检查清单 / Checklist

- [x] 😊 本 PR 为 bug 修复，无新增功能。
- [x] 👀 我的更改经过了良好的测试，并已在上方提供了测试日志。
- [x] 🤓 我确保没有引入新依赖库。
- [x] 😮 我的更改没有引入恶意代码。

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的贡献指南。
