### PR TITLE
feat: 主动消息支持配图、链式工具调用、模型回退与人格自选

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -183,6 +183,18 @@
                         "type": "string",
                         "default": "",
                         "hint": "附加在配图决策提示后的额外说明，例如画风偏好。留空则仅依据消息内容自行判断。"
+                    },
+                    "extra_tools": {
+                        "description": "➕ 额外生图工具名（可选）",
+                        "type": "list",
+                        "default": [],
+                        "hint": "默认会按关键词（draw/image/生图/绘图 等，匹配工具名与描述）自动识别生图工具。如果你的生图插件工具名不含这些关键词（例如 nano_banana、flux），在这里补上它的 LLM 工具名，每行一个。"
+                    },
+                    "exclude_tools": {
+                        "description": "➖ 排除的工具名（可选）",
+                        "type": "list",
+                        "default": [],
+                        "hint": "如果自动识别误把某个非生图工具当成了生图工具（例如 read_image_file 这类），在这里填它的名字排除掉，每行一个。"
                     }
                 }
             },
@@ -488,6 +500,18 @@
                         "type": "string",
                         "default": "",
                         "hint": "附加在配图决策提示后的额外说明，例如画风偏好。留空则仅依据消息内容自行判断。"
+                    },
+                    "extra_tools": {
+                        "description": "➕ 额外生图工具名（可选）",
+                        "type": "list",
+                        "default": [],
+                        "hint": "默认会按关键词（draw/image/生图/绘图 等，匹配工具名与描述）自动识别生图工具。如果你的生图插件工具名不含这些关键词（例如 nano_banana、flux），在这里补上它的 LLM 工具名，每行一个。"
+                    },
+                    "exclude_tools": {
+                        "description": "➖ 排除的工具名（可选）",
+                        "type": "list",
+                        "default": [],
+                        "hint": "如果自动识别误把某个非生图工具当成了生图工具（例如 read_image_file 这类），在这里填它的名字排除掉，每行一个。"
                     }
                 }
             },

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -158,6 +158,34 @@
                     }
                 }
             },
+            "image_settings": {
+                "description": "🖼️ 私聊主动消息配图设置",
+                "type": "object",
+                "items": {
+                    "mode": {
+                        "description": "🎨 配图模式",
+                        "type": "string",
+                        "options": [
+                            "off",
+                            "auto",
+                            "always"
+                        ],
+                        "default": "off",
+                        "labels": [
+                            "不生图",
+                            "Bot 自行判断",
+                            "直接生图"
+                        ],
+                        "hint": "off=只发文本；auto=让模型判断这条消息是否适合配图并自行调用可用的生图工具；always=尽量为每条主动消息配图。依赖你已安装的任意生图插件（向主 LLM 注册了工具），未安装则自动只发文本。"
+                    },
+                    "extra_prompt": {
+                        "description": "📝 配图引导补充（可选）",
+                        "type": "string",
+                        "default": "",
+                        "hint": "附加在配图决策提示后的额外说明，例如画风偏好。留空则仅依据消息内容自行判断。"
+                    }
+                }
+            },
             "segmented_reply_settings": {
                 "description": "🔪 分段回复设置",
                 "type": "object",
@@ -432,6 +460,34 @@
                         "type": "bool",
                         "default": true,
                         "hint": "开启后，即使 TTS 成功发送了语音，也会再发送一条纯文本原文，确保所有人都能看到内容"
+                    }
+                }
+            },
+            "image_settings": {
+                "description": "🖼️ 群聊主动消息配图设置",
+                "type": "object",
+                "items": {
+                    "mode": {
+                        "description": "🎨 配图模式",
+                        "type": "string",
+                        "options": [
+                            "off",
+                            "auto",
+                            "always"
+                        ],
+                        "default": "off",
+                        "labels": [
+                            "不生图",
+                            "Bot 自行判断",
+                            "直接生图"
+                        ],
+                        "hint": "off=只发文本；auto=让模型判断这条消息是否适合配图并自行调用可用的生图工具；always=尽量为每条主动消息配图。依赖你已安装的任意生图插件（向主 LLM 注册了工具），未安装则自动只发文本。"
+                    },
+                    "extra_prompt": {
+                        "description": "📝 配图引导补充（可选）",
+                        "type": "string",
+                        "default": "",
+                        "hint": "附加在配图决策提示后的额外说明，例如画风偏好。留空则仅依据消息内容自行判断。"
                     }
                 }
             },

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -198,6 +198,111 @@
                     }
                 }
             },
+            "agent_settings": {
+                "description": "🛠️ 主动消息工具调用与模型回退",
+                "type": "object",
+                "items": {
+                    "tool_mode": {
+                        "description": "🔧 工具调用模式",
+                        "type": "string",
+                        "options": [
+                            "off",
+                            "whitelist",
+                            "all"
+                        ],
+                        "default": "off",
+                        "labels": [
+                            "不调用工具",
+                            "仅白名单工具",
+                            "全部已注册工具"
+                        ],
+                        "hint": "off=维持现状，单次生成正文不调用任何工具；whitelist=只把下方“包含工具名”里填写的工具暴露给主动消息的 Agent，由模型在一次主动消息里按需多次调用（链式工具调用）；all=暴露全部已注册工具（风险较高，可能触及删文件/发消息等工具，请谨慎）。"
+                    },
+                    "include_tools": {
+                        "description": "➕ 包含工具名（whitelist 模式）",
+                        "type": "list",
+                        "default": [],
+                        "condition": {
+                            "tool_mode": "whitelist"
+                        },
+                        "hint": "whitelist 模式下要暴露给 Agent 的 LLM 工具名，每行一个（例如 get_weather、search_news）。仅在 tool_mode=whitelist 时生效。"
+                    },
+                    "exclude_tools": {
+                        "description": "➖ 排除工具名",
+                        "type": "list",
+                        "default": [],
+                        "hint": "任何模式下都会强制排除的工具名，每行一个。用于从 all 全集或自动选择中剔除不希望主动消息使用的工具。"
+                    },
+                    "max_steps": {
+                        "description": "🔁 工具循环最大步数",
+                        "type": "int",
+                        "default": 0,
+                        "hint": "一次主动消息中允许的最大工具调用步数，防止工具循环失控或刷 token。0=自动（按本次暴露的工具数推导，约为工具数×2+2，范围 3~30）；填正数则固定为该值。",
+                        "slider": {
+                            "min": 0,
+                            "max": 30,
+                            "step": 1
+                        }
+                    },
+                    "model_fallback_enable": {
+                        "description": "🔀 启用模型自动回退",
+                        "type": "bool",
+                        "default": false,
+                        "hint": "开启后，当首选模型不可用（限流/报错/空输出）时，自动顺延切换到备选模型。适合薅 ModelScope 等免费但限流严格的平台。注意：开启后正文生成会改走工具循环 Agent（即使不配工具，也只是带回退的单次调用）。"
+                    },
+                    "model_fallback_models": {
+                        "description": "📋 备选模型 Provider ID（可选）",
+                        "type": "list",
+                        "items": {
+                            "type": "string"
+                        },
+                        "_special": "select_providers",
+                        "default": [],
+                        "hint": "按优先顺序选择备选对话模型，主模型请求失败时按顺序切换。留空且已启用回退时，将自动读取 AstrBot 全局“服务提供商设置”里的 fallback_chat_models，与本体回退行为对齐。"
+                    }
+                }
+            },
+            "persona_settings": {
+                "description": "🎭 主动消息人格设置",
+                "type": "object",
+                "items": {
+                    "persona_mode": {
+                        "description": "🎭 人格来源",
+                        "type": "string",
+                        "options": [
+                            "off",
+                            "select",
+                            "custom"
+                        ],
+                        "default": "off",
+                        "labels": [
+                            "跟随会话/默认",
+                            "选择已有人格",
+                            "自定义人格"
+                        ],
+                        "hint": "off=维持现状，按“会话人格→默认人格”自动选择；select=为主动消息指定一个已有人格，严格覆盖会话与默认人格；custom=直接填写一段人格提示词作为主动消息的人设，同样严格覆盖。"
+                    },
+                    "persona_id": {
+                        "description": "🎭 选择人格（select 模式）",
+                        "type": "string",
+                        "_special": "select_persona",
+                        "default": "",
+                        "condition": {
+                            "persona_mode": "select"
+                        },
+                        "hint": "select 模式下为主动消息指定的人格。留空则回退为现状的“会话人格→默认人格”自动选择。"
+                    },
+                    "custom_persona": {
+                        "description": "📝 自定义人格提示词（custom 模式）",
+                        "type": "text",
+                        "default": "",
+                        "condition": {
+                            "persona_mode": "custom"
+                        },
+                        "hint": "custom 模式下直接作为主动消息的人格提示词（system prompt）使用。留空则回退为现状的“会话人格→默认人格”自动选择。"
+                    }
+                }
+            },
             "segmented_reply_settings": {
                 "description": "🔪 分段回复设置",
                 "type": "object",
@@ -512,6 +617,111 @@
                         "type": "list",
                         "default": [],
                         "hint": "如果自动识别误把某个非生图工具当成了生图工具（例如 read_image_file 这类），在这里填它的名字排除掉，每行一个。"
+                    }
+                }
+            },
+            "agent_settings": {
+                "description": "🛠️ 主动消息工具调用与模型回退",
+                "type": "object",
+                "items": {
+                    "tool_mode": {
+                        "description": "🔧 工具调用模式",
+                        "type": "string",
+                        "options": [
+                            "off",
+                            "whitelist",
+                            "all"
+                        ],
+                        "default": "off",
+                        "labels": [
+                            "不调用工具",
+                            "仅白名单工具",
+                            "全部已注册工具"
+                        ],
+                        "hint": "off=维持现状，单次生成正文不调用任何工具；whitelist=只把下方“包含工具名”里填写的工具暴露给主动消息的 Agent，由模型在一次主动消息里按需多次调用（链式工具调用）；all=暴露全部已注册工具（风险较高，可能触及删文件/发消息等工具，请谨慎）。"
+                    },
+                    "include_tools": {
+                        "description": "➕ 包含工具名（whitelist 模式）",
+                        "type": "list",
+                        "default": [],
+                        "condition": {
+                            "tool_mode": "whitelist"
+                        },
+                        "hint": "whitelist 模式下要暴露给 Agent 的 LLM 工具名，每行一个（例如 get_weather、search_news）。仅在 tool_mode=whitelist 时生效。"
+                    },
+                    "exclude_tools": {
+                        "description": "➖ 排除工具名",
+                        "type": "list",
+                        "default": [],
+                        "hint": "任何模式下都会强制排除的工具名，每行一个。用于从 all 全集或自动选择中剔除不希望主动消息使用的工具。"
+                    },
+                    "max_steps": {
+                        "description": "🔁 工具循环最大步数",
+                        "type": "int",
+                        "default": 0,
+                        "hint": "一次主动消息中允许的最大工具调用步数，防止工具循环失控或刷 token。0=自动（按本次暴露的工具数推导，约为工具数×2+2，范围 3~30）；填正数则固定为该值。",
+                        "slider": {
+                            "min": 0,
+                            "max": 30,
+                            "step": 1
+                        }
+                    },
+                    "model_fallback_enable": {
+                        "description": "🔀 启用模型自动回退",
+                        "type": "bool",
+                        "default": false,
+                        "hint": "开启后，当首选模型不可用（限流/报错/空输出）时，自动顺延切换到备选模型。适合薅 ModelScope 等免费但限流严格的平台。注意：开启后正文生成会改走工具循环 Agent（即使不配工具，也只是带回退的单次调用）。"
+                    },
+                    "model_fallback_models": {
+                        "description": "📋 备选模型 Provider ID（可选）",
+                        "type": "list",
+                        "items": {
+                            "type": "string"
+                        },
+                        "_special": "select_providers",
+                        "default": [],
+                        "hint": "按优先顺序选择备选对话模型，主模型请求失败时按顺序切换。留空且已启用回退时，将自动读取 AstrBot 全局“服务提供商设置”里的 fallback_chat_models，与本体回退行为对齐。"
+                    }
+                }
+            },
+            "persona_settings": {
+                "description": "🎭 主动消息人格设置",
+                "type": "object",
+                "items": {
+                    "persona_mode": {
+                        "description": "🎭 人格来源",
+                        "type": "string",
+                        "options": [
+                            "off",
+                            "select",
+                            "custom"
+                        ],
+                        "default": "off",
+                        "labels": [
+                            "跟随会话/默认",
+                            "选择已有人格",
+                            "自定义人格"
+                        ],
+                        "hint": "off=维持现状，按“会话人格→默认人格”自动选择；select=为主动消息指定一个已有人格，严格覆盖会话与默认人格；custom=直接填写一段人格提示词作为主动消息的人设，同样严格覆盖。"
+                    },
+                    "persona_id": {
+                        "description": "🎭 选择人格（select 模式）",
+                        "type": "string",
+                        "_special": "select_persona",
+                        "default": "",
+                        "condition": {
+                            "persona_mode": "select"
+                        },
+                        "hint": "select 模式下为主动消息指定的人格。留空则回退为现状的“会话人格→默认人格”自动选择。"
+                    },
+                    "custom_persona": {
+                        "description": "📝 自定义人格提示词（custom 模式）",
+                        "type": "text",
+                        "default": "",
+                        "condition": {
+                            "persona_mode": "custom"
+                        },
+                        "hint": "custom 模式下直接作为主动消息的人格提示词（system prompt）使用。留空则回退为现状的“会话人格→默认人格”自动选择。"
                     }
                 }
             },

--- a/core/agent_runner.py
+++ b/core/agent_runner.py
@@ -309,7 +309,7 @@ class AgentRunnerMixin:
                 if selected is not None and not selected.empty():
                     tool_set = selected
                     logger.info(
-                        f"[主动消息] 链式工具调用已启用，共暴露 {len(tool_set.func_list)} 个工具喵。"
+                        f"[主动消息] 链式工具调用已启用，共暴露 {len(tool_set.tools)} 个工具喵。"
                     )
                 else:
                     logger.info(
@@ -330,7 +330,7 @@ class AgentRunnerMixin:
 
         # max_steps：0（或缺省/非法）表示自动——按本次暴露的工具数推导一个上限；
         # 填正数则视为用户指定的固定上限。
-        tool_count = len(tool_set.func_list) if tool_set is not None else 0
+        tool_count = len(tool_set.tools) if tool_set is not None else 0
         max_steps = self._compute_max_steps(
             (agent_conf or {}).get("max_steps", 0), tool_count
         )

--- a/core/agent_runner.py
+++ b/core/agent_runner.py
@@ -1,0 +1,374 @@
+"""主动消息链式工具调用与模型自动回退能力。
+
+通过 AstrBot 的工具循环 Agent（``context.tool_loop_agent``），让主动消息的正文
+生成具备两项能力（对应 issue #56）：
+
+1. 链式工具调用：在一次主动消息里，由模型按需多次调用已注册的工具（如查天气、
+   查新闻、读文件），再据此生成最终要发送的文本。
+2. 模型自动回退：首选模型不可用（限流/报错/空输出）时，自动顺延切换到备选模型。
+   复用本体 ``ToolLoopAgentRunner`` 的 ``fallback_providers`` 机制。
+
+设计要点：
+- 默认关闭：tool_mode=off 且未开回退时，调用方应继续走原有的单次 LLM 生成路径。
+- 合成事件吞掉发送：工具在循环中调用 ``event.send`` 的中间产物不会真正发往平台，
+  最终消息只取 Agent 的 ``completion_text``，避免把工具原始数据发给用户。
+- 失败静默降级：任何环节出错都只记录日志并返回 None，由调用方回退为单次生成。
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any
+
+from astrbot.api import logger
+
+try:
+    from astrbot.core.agent.tool import ToolSet
+    from astrbot.core.message.components import Image, Plain
+    from astrbot.core.platform.astr_message_event import AstrMessageEvent
+    from astrbot.core.platform.astrbot_message import AstrBotMessage, MessageMember
+    from astrbot.core.platform.message_session import MessageSession
+    from astrbot.core.platform.message_type import MessageType
+    from astrbot.core.platform.platform_metadata import PlatformMetadata
+    from astrbot.core.provider.provider import Provider
+
+    _AGENT_AVAILABLE = True
+except ImportError as _e:  # pragma: no cover - 取决于宿主版本
+    _AGENT_AVAILABLE = False
+    Provider = object  # type: ignore[assignment, misc]
+    logger.warning(f"[主动消息] 当前 AstrBot 版本不支持链式工具调用所需组件喵: {_e}")
+
+
+# 占位符，便于在依赖缺失时仍能定义类型注解。
+_BaseEvent = AstrMessageEvent if _AGENT_AVAILABLE else object
+
+
+class ProactiveAgentEvent(_BaseEvent):  # type: ignore[misc, valid-type]
+    """主动消息工具循环用的统一合成事件。
+
+    构造一个不绑定真实平台连接的合成事件供工具循环 Agent 使用，并重写 ``send``：
+    - 捕获其中的图片组件到 ``captured_images``（供配图能力取用）；
+    - 其余内容一律吞掉，不真正发往平台。
+
+    这样同一个事件既能服务于“正文工具循环”（只取 Agent 的 ``completion_text``），
+    也能服务于“配图工具循环”（取 ``captured_images``），消除两套几乎一致的合成事件。
+    """
+
+    def __init__(
+        self,
+        *,
+        context: Any,
+        session: "MessageSession",
+        message: str,
+        message_type: "MessageType",
+    ) -> None:
+        platform_meta = PlatformMetadata(
+            name="proactive_agent",
+            description="ProactiveChat 工具循环合成事件",
+            id=session.platform_id,
+        )
+
+        msg_obj = AstrBotMessage()
+        msg_obj.type = message_type
+        msg_obj.self_id = "astrbot"
+        msg_obj.session_id = session.session_id
+        msg_obj.message_id = uuid.uuid4().hex
+        msg_obj.sender = MessageMember(user_id=session.session_id, nickname="主动消息")
+        msg_obj.message = [Plain(message)]
+        msg_obj.message_str = message
+        msg_obj.raw_message = message
+        msg_obj.timestamp = int(time.time())
+
+        super().__init__(message, msg_obj, platform_meta, session.session_id)
+
+        # 使用原始会话，保证工具内部读取 unified_msg_origin 等信息时一致。
+        self.session = session
+        self.context_obj = context
+        self.is_at_or_wake_command = True
+        self.is_wake = True
+
+        # 收集被拦截的图片组件，供配图能力在 Agent 结束后取用。
+        self.captured_images: list["Image"] = []
+
+    async def send(self, message: Any) -> None:
+        """拦截发送：收集图片组件，其余内容一律吞掉，均不真正发往平台。
+
+        兼容多种传入形式：MessageChain（含 .chain）、组件列表/元组、单个组件——
+        因为第三方工具调用 ``event.send`` 的写法不完全一致。
+        """
+        try:
+            if message is not None:
+                chain = getattr(message, "chain", None)
+                if chain is not None:
+                    comps = chain
+                elif isinstance(message, (list, tuple)):
+                    comps = message
+                else:
+                    comps = [message]
+                for comp in comps:
+                    if isinstance(comp, Image):
+                        self.captured_images.append(comp)
+        except Exception as e:  # noqa: BLE001 - 拦截阶段不应影响主流程
+            logger.debug(f"[主动消息] 捕获组件时出现异常喵: {e!r}")
+        # 故意不调用 super().send()，避免触发真实平台发送与统计。
+
+    async def send_streaming(self, generator, use_fallback: bool = False) -> None:
+        async for chain in generator:
+            await self.send(chain)
+
+
+class AgentRunnerMixin:
+    """为主动消息提供链式工具调用与模型回退能力的 Mixin。"""
+
+    context: Any
+
+    @staticmethod
+    def _parse_tool_name_list(raw: Any) -> list[str]:
+        """把配置值解析为工具名列表。
+
+        兼容 list 与逗号/换行分隔的字符串两种写法，去重并保持顺序。
+        """
+        names: list[str] = []
+        if isinstance(raw, str):
+            for piece in raw.replace("\n", ",").split(","):
+                piece = piece.strip()
+                if piece:
+                    names.append(piece)
+        elif isinstance(raw, (list, tuple)):
+            for item in raw:
+                piece = str(item).strip()
+                if piece:
+                    names.append(piece)
+        seen: set[str] = set()
+        result: list[str] = []
+        for n in names:
+            if n not in seen:
+                seen.add(n)
+                result.append(n)
+        return result
+
+    @staticmethod
+    def _compute_max_steps(raw_value: Any, tool_count: int) -> int:
+        """计算工具循环最大步数。
+
+        raw_value<=0（或非法）：自动——按工具数推导（每个工具留“调用+追问”两步，
+        再加 2 步余量），clamp 到 [3, 30]。
+        raw_value>0：用户指定的固定上限，clamp 到 [1, 30]。
+        """
+        try:
+            configured = int(raw_value or 0)
+        except Exception:  # noqa: BLE001
+            configured = 0
+        if configured > 0:
+            return max(1, min(configured, 30))
+        count = max(0, int(tool_count or 0))
+        return max(3, min(count * 2 + 2, 30))
+
+    def _select_agent_tools(self, tool_manager: Any, agent_conf: dict) -> Any:
+        """按 tool_mode 选出交给 Agent 的工具集（ToolSet，可能为空）。
+
+        - whitelist：仅取 include_tools 命中的工具。
+        - all：取全部已注册工具（func_list）。
+        两种模式都会减去 exclude_tools。off 模式不应调用本方法。
+        """
+        mode = str((agent_conf or {}).get("tool_mode", "off") or "off").strip().lower()
+        include = self._parse_tool_name_list(
+            (agent_conf or {}).get("include_tools", [])
+        )
+        exclude = set(
+            self._parse_tool_name_list((agent_conf or {}).get("exclude_tools", []))
+        )
+
+        tool_set = ToolSet()
+        if mode == "whitelist":
+            for name in include:
+                if name in exclude:
+                    continue
+                tool = (
+                    tool_manager.get_func(name)
+                    if hasattr(tool_manager, "get_func")
+                    else None
+                )
+                if tool is not None:
+                    tool_set.add_tool(tool)
+        elif mode == "all":
+            try:
+                all_tools = list(getattr(tool_manager, "func_list", []) or [])
+            except Exception:  # noqa: BLE001
+                all_tools = []
+            for tool in all_tools:
+                name = getattr(tool, "name", "") or ""
+                if name and name not in exclude:
+                    tool_set.add_tool(tool)
+        return tool_set
+
+    def _resolve_fallback_providers(
+        self,
+        session_id: str,
+        primary_provider_id: str,
+        agent_conf: dict,
+    ) -> list[Any]:
+        """解析模型回退用的备选 Provider 列表，对齐本体 _get_fallback_chat_providers。
+
+        优先读插件本地的 model_fallback_models；留空则回退读取 AstrBot 全局
+        provider_settings.fallback_chat_models。逐个解析为 Provider，仅保留有效的
+        对话模型，去重并剔除主 Provider。
+        """
+        fallback_ids = self._parse_tool_name_list(
+            (agent_conf or {}).get("model_fallback_models", [])
+        )
+
+        # 本地列表为空时，回退读取全局配置（与本体行为对齐）。
+        if not fallback_ids:
+            try:
+                global_conf = self.context.get_config(session_id)
+            except Exception:  # noqa: BLE001
+                global_conf = None
+            if global_conf is None:
+                try:
+                    global_conf = self.context.get_config()
+                except Exception:  # noqa: BLE001
+                    global_conf = None
+            provider_settings = {}
+            if isinstance(global_conf, dict):
+                provider_settings = global_conf.get("provider_settings", {}) or {}
+            elif global_conf is not None:
+                provider_settings = getattr(global_conf, "provider_settings", {}) or {}
+            raw_global = (
+                provider_settings.get("fallback_chat_models", [])
+                if isinstance(provider_settings, dict)
+                else []
+            )
+            fallback_ids = self._parse_tool_name_list(raw_global)
+
+        seen: set[str] = set()
+        if primary_provider_id:
+            seen.add(primary_provider_id)
+
+        providers: list[Any] = []
+        for fid in fallback_ids:
+            if fid in seen:
+                continue
+            try:
+                prov = self.context.get_provider_by_id(fid)
+            except Exception:  # noqa: BLE001
+                prov = None
+            if prov is None:
+                logger.warning(
+                    f"[主动消息] 备选模型 Provider “{fid}” 未找到，已跳过喵。"
+                )
+                continue
+            if _AGENT_AVAILABLE and not isinstance(prov, Provider):
+                logger.warning(
+                    f"[主动消息] 备选模型 Provider “{fid}” 类型不正确，已跳过喵。"
+                )
+                continue
+            providers.append(prov)
+            seen.add(fid)
+        return providers
+
+    async def _run_proactive_agent(
+        self,
+        session_id: str,
+        prompt: str,
+        contexts: list,
+        system_prompt: str,
+        agent_conf: dict,
+    ) -> str | None:
+        """用工具循环 Agent 生成主动消息正文，支持链式工具调用与模型回退。
+
+        返回生成的文本；任何环节失败都返回 None，由调用方降级为单次生成。
+        """
+        if not _AGENT_AVAILABLE:
+            logger.warning(
+                "[主动消息] 当前 AstrBot 版本不支持工具循环 Agent，回退为单次生成喵。"
+            )
+            return None
+
+        try:
+            provider_id = await self.context.get_current_chat_provider_id(session_id)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"[主动消息] 获取当前对话 Provider 失败喵: {e!r}")
+            return None
+        if not provider_id:
+            logger.info("[主动消息] 未找到可用对话 Provider，回退为单次生成喵。")
+            return None
+
+        mode = str((agent_conf or {}).get("tool_mode", "off") or "off").strip().lower()
+
+        # 仅在需要工具时构建 ToolSet；off 模式（只为回退而走 Agent）不带工具。
+        tool_set = None
+        if mode in ("whitelist", "all"):
+            try:
+                tool_manager = self.context.get_llm_tool_manager()
+            except Exception:  # noqa: BLE001
+                tool_manager = None
+            if tool_manager is not None:
+                selected = self._select_agent_tools(tool_manager, agent_conf)
+                if selected is not None and not selected.empty():
+                    tool_set = selected
+                    logger.info(
+                        f"[主动消息] 链式工具调用已启用，共暴露 {len(tool_set.func_list)} 个工具喵。"
+                    )
+                else:
+                    logger.info(
+                        "[主动消息] 未选出可用工具，本次仅按普通对话方式生成喵。"
+                    )
+
+        # 解析回退 Provider 列表（开启回退时）。
+        fallback_providers = None
+        if (agent_conf or {}).get("model_fallback_enable", False):
+            resolved = self._resolve_fallback_providers(
+                session_id, provider_id, agent_conf
+            )
+            if resolved:
+                fallback_providers = resolved
+                logger.info(
+                    f"[主动消息] 模型自动回退已启用，备选模型 {len(resolved)} 个喵。"
+                )
+
+        # max_steps：0（或缺省/非法）表示自动——按本次暴露的工具数推导一个上限；
+        # 填正数则视为用户指定的固定上限。
+        tool_count = len(tool_set.func_list) if tool_set is not None else 0
+        max_steps = self._compute_max_steps(
+            (agent_conf or {}).get("max_steps", 0), tool_count
+        )
+        logger.info(
+            f"[主动消息] 工具循环最大步数为 {max_steps}（工具数 {tool_count}）喵。"
+        )
+
+        session = MessageSession.from_str(session_id)
+        agent_event = ProactiveAgentEvent(
+            context=self.context,
+            session=session,
+            message=prompt,
+            message_type=session.message_type,
+        )
+
+        kwargs: dict[str, Any] = {
+            "event": agent_event,
+            "chat_provider_id": provider_id,
+            "prompt": prompt,
+            "contexts": contexts,
+            "system_prompt": system_prompt,
+            "max_steps": max_steps,
+        }
+        if tool_set is not None:
+            kwargs["tools"] = tool_set
+        if fallback_providers:
+            kwargs["fallback_providers"] = fallback_providers
+
+        try:
+            resp = await self.context.tool_loop_agent(**kwargs)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                f"[主动消息] 工具循环 Agent 执行失败，回退为单次生成喵: {e!r}"
+            )
+            return None
+
+        text = (getattr(resp, "completion_text", "") or "").strip()
+        if not text:
+            logger.info("[主动消息] 工具循环 Agent 未产出文本，回退为单次生成喵。")
+            return None
+        return text

--- a/core/image_generator.py
+++ b/core/image_generator.py
@@ -102,20 +102,6 @@ class _ImageCaptureEvent(_BaseEvent):  # type: ignore[misc, valid-type]
             await self.send(chain)
 
 
-# 引导模型决定是否配图的系统提示。
-_AUTO_SYSTEM_PROMPT = (
-    "你刚刚生成了一条要主动发给用户的消息。现在请判断这条消息是否适合配一张图片。\n"
-    "- 如果适合（例如描述了某个画面、场景、物品、表情、心情且配图能增强表达），"
-    "请调用一个可用的生图工具来生成与消息内容相符的图片。\n"
-    "- 如果不适合（例如纯粹的问候、提问、抽象表达），则不要调用任何工具，直接结束。\n"
-    "不要输出多余的解释，只在需要时调用生图工具。"
-)
-_ALWAYS_SYSTEM_PROMPT = (
-    "你刚刚生成了一条要主动发给用户的消息。请调用一个可用的生图工具，生成一张"
-    "与这条消息内容相符的配图。请直接调用工具，不要输出多余解释。"
-)
-
-
 class ImageMixin:
     """为主动消息提供“配图”能力的 Mixin。"""
 
@@ -295,6 +281,53 @@ class ImageMixin:
             logger.info("[主动消息] 已找到可用的生图工具喵。")
         # 预热选不到不记失败、不打 warning，留给发送时按需重试。
 
+    # auto 模式下，模型判断无需配图时回复的固定标记。
+    _NO_IMAGE_TOKEN = "NO_IMAGE"
+
+    async def _generate_image_prompt(
+        self, provider_id: str, text: str, image_conf: dict, mode: str
+    ) -> str:
+        """由插件端调用 LLM，把主动消息文本转成一段“画面描述”（生图提示词）。
+
+        - always 模式：总是生成一段画面描述。
+        - auto 模式：先让模型判断是否适合配图，不适合则返回空字符串。
+        失败一律返回空字符串（跳过配图，不影响文本）。
+        """
+        extra = str((image_conf or {}).get("extra_prompt", "") or "").strip()
+        if mode == "always":
+            system_prompt = (
+                "你是配图提示词助手。请根据给定的消息内容，写出一段适合用来生图的"
+                "画面描述（中文或英文均可），聚焦可视画面：主体、场景、氛围、风格。"
+                "只输出画面描述本身，不要解释、不要加引号。"
+            )
+        else:
+            system_prompt = (
+                "你是配图提示词助手。请判断给定的消息是否适合配一张图片：\n"
+                f"- 不适合（如纯问候、提问、抽象表达）：只回复 {self._NO_IMAGE_TOKEN}。\n"
+                "- 适合：写出一段适合用来生图的画面描述（聚焦主体、场景、氛围、风格），"
+                "只输出画面描述本身，不要解释、不要加引号。"
+            )
+        if extra:
+            system_prompt = f"{system_prompt}\n补充要求：{extra}"
+
+        try:
+            resp = await self.context.llm_generate(
+                chat_provider_id=provider_id,
+                prompt=f"消息内容：\n{text}",
+                system_prompt=system_prompt,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"[主动消息] 生成配图提示词失败喵: {e!r}")
+            return ""
+
+        prompt = (getattr(resp, "completion_text", "") or "").strip()
+        if not prompt:
+            return ""
+        # auto 模式下命中“无需配图”标记则跳过。
+        if mode != "always" and self._NO_IMAGE_TOKEN in prompt.upper():
+            return ""
+        return prompt
+
     async def _run_image_agent(
         self, session_id: str, text: str, image_conf: dict, mode: str
     ) -> list:
@@ -334,11 +367,30 @@ class ImageMixin:
             message_type=session.message_type,
         )
 
-        base_prompt = _ALWAYS_SYSTEM_PROMPT if mode == "always" else _AUTO_SYSTEM_PROMPT
-        extra = str(image_conf.get("extra_prompt", "") or "").strip()
-        system_prompt = f"{base_prompt}\n\n{extra}" if extra else base_prompt
+        # 第一步：由插件端先生成“画面描述”（生图提示词）。
+        # auto 模式下若模型判断这条消息不适合配图，会返回空，此时直接跳过。
+        image_prompt = await self._generate_image_prompt(
+            provider_id, text, image_conf, mode
+        )
+        if not image_prompt:
+            logger.info("[主动消息] 未生成配图提示词（判断无需配图），跳过配图喵。")
+            return []
 
-        user_prompt = f"这是要发送的主动消息内容：\n{text}"
+        capture_event = _ImageCaptureEvent(
+            context=context,
+            session=session,
+            message=text,
+            message_type=session.message_type,
+        )
+
+        # 第二步：把插件生成好的画面描述作为明确指令交给 Agent，让它据此调用生图
+        # 工具——描述由插件掌控，要求模型原样使用、不要改写或自行编造。
+        system_prompt = (
+            "你的唯一任务是调用一个可用的生图工具，为下面给出的画面描述生成图片。\n"
+            "请把画面描述原样作为生图工具的绘画提示词，不要改写、缩写或自行发挥；\n"
+            "调用工具即可，不要输出多余文字。"
+        )
+        user_prompt = f"画面描述：\n{image_prompt}"
 
         await context.tool_loop_agent(
             event=capture_event,
@@ -353,5 +405,5 @@ class ImageMixin:
         if images:
             logger.info(f"[主动消息] 配图 Agent 共捕获 {len(images)} 张图片喵。")
         else:
-            logger.info("[主动消息] 配图 Agent 未产出图片（模型判断无需配图或工具未生图）喵。")
+            logger.info("[主动消息] 配图 Agent 未产出图片（工具未生图或调用失败）喵。")
         return images

--- a/core/image_generator.py
+++ b/core/image_generator.py
@@ -16,101 +16,18 @@
 
 from __future__ import annotations
 
-import time
-import uuid
-from typing import Any
-
 from astrbot.api import logger
+
+from .agent_runner import ProactiveAgentEvent
 
 try:
     from astrbot.core.agent.tool import ToolSet
-    from astrbot.core.message.components import Image, Plain
-    from astrbot.core.platform.astr_message_event import AstrMessageEvent
-    from astrbot.core.platform.astrbot_message import AstrBotMessage, MessageMember
     from astrbot.core.platform.message_session import MessageSession
-    from astrbot.core.platform.message_type import MessageType
-    from astrbot.core.platform.platform_metadata import PlatformMetadata
 
     _IMAGE_AGENT_AVAILABLE = True
 except ImportError as _e:  # pragma: no cover - 取决于宿主版本
     _IMAGE_AGENT_AVAILABLE = False
     logger.warning(f"[主动消息] 当前 AstrBot 版本不支持配图 Agent 所需组件喵: {_e}")
-
-
-# 占位符，便于在依赖缺失时仍能定义类型注解。
-_BaseEvent = AstrMessageEvent if _IMAGE_AGENT_AVAILABLE else object
-
-
-class _ImageCaptureEvent(_BaseEvent):  # type: ignore[misc, valid-type]
-    """捕获型合成事件。
-
-    参考 AstrBot 官方的 ``CronMessageEvent`` 构造一个不绑定真实平台连接的合成
-    事件，供工具循环 Agent 使用。与之不同的是：本事件重写 ``send`` ，把生图
-    插件试图发送的图片 **拦截到内部缓冲区** ，而不是真正发往平台——从而让本
-    插件能拿回图片、自行决定如何发送。
-    """
-
-    def __init__(
-        self,
-        *,
-        context: Any,
-        session: "MessageSession",
-        message: str,
-        message_type: "MessageType",
-    ) -> None:
-        platform_meta = PlatformMetadata(
-            name="proactive_image",
-            description="ProactiveChat 配图合成事件",
-            id=session.platform_id,
-        )
-
-        msg_obj = AstrBotMessage()
-        msg_obj.type = message_type
-        msg_obj.self_id = "astrbot"
-        msg_obj.session_id = session.session_id
-        msg_obj.message_id = uuid.uuid4().hex
-        msg_obj.sender = MessageMember(user_id=session.session_id, nickname="主动消息")
-        msg_obj.message = [Plain(message)]
-        msg_obj.message_str = message
-        msg_obj.raw_message = message
-        msg_obj.timestamp = int(time.time())
-
-        super().__init__(message, msg_obj, platform_meta, session.session_id)
-
-        # 使用原始会话，保证工具内部读取 unified_msg_origin 等信息时一致。
-        self.session = session
-        self.context_obj = context
-        self.is_at_or_wake_command = True
-        self.is_wake = True
-
-        # 收集被拦截的图片组件，供 Agent 结束后取用。
-        self.captured_images: list["Image"] = []
-
-    async def send(self, message: Any) -> None:
-        """拦截发送：仅收集图片组件，不真正发往平台。
-
-        兼容多种传入形式：MessageChain（含 .chain）、组件列表/元组、单个组件——
-        因为第三方生图插件调用 ``event.send`` 的写法不完全一致。
-        """
-        try:
-            if message is not None:
-                chain = getattr(message, "chain", None)
-                if chain is not None:
-                    comps = chain
-                elif isinstance(message, (list, tuple)):
-                    comps = message
-                else:
-                    comps = [message]
-                for comp in comps:
-                    if isinstance(comp, Image):
-                        self.captured_images.append(comp)
-        except Exception as e:  # noqa: BLE001 - 拦截阶段不应影响主流程
-            logger.debug(f"[主动消息] 捕获配图组件时出现异常喵: {e!r}")
-        # 故意不调用 super().send()，避免触发真实平台发送与统计。
-
-    async def send_streaming(self, generator, use_fallback: bool = False) -> None:
-        async for chain in generator:
-            await self.send(chain)
 
 
 class ImageMixin:
@@ -435,7 +352,7 @@ class ImageMixin:
             logger.info("[主动消息] 未生成配图提示词（判断无需配图），跳过配图喵。")
             return []
 
-        capture_event = _ImageCaptureEvent(
+        capture_event = ProactiveAgentEvent(
             context=context,
             session=session,
             message=text,

--- a/core/image_generator.py
+++ b/core/image_generator.py
@@ -1,14 +1,15 @@
 """主动消息配图能力。
 
-通过 AstrBot 的工具循环 Agent，让主 LLM 在生成主动消息后自行判断/调用
-任意已安装的生图插件（向主 LLM 注册了工具的插件）来生成配图。生成的图片
-不会由生图插件直接发往平台，而是被一个“捕获型”合成事件拦截、收集后交还给
-本插件，统一走主动消息既有的发送流程（分段、装饰钩子、平台历史持久化）。
+通过 AstrBot 的工具循环 Agent，让主 LLM 调用已安装的生图插件（向主 LLM
+注册了工具的插件）来生成配图。生成的图片不会由生图插件直接发往平台，而是被一个
+“捕获型”合成事件拦截、收集后交还给本插件，统一走主动消息既有的发送流程
+（分段、装饰钩子、平台历史持久化）。
 
 设计要点：
-- provider 无关：不绑定任何特定生图插件，依赖 ``get_full_tool_set`` 暴露的
-  全部已注册工具，由模型自行选择。
-- 不改动 AstrBot 源码：仅继承公开基类、调用公开 API。
+- provider 无关：不绑定任何特定生图插件，按关键词（工具名 + 描述）自动识别生图
+  工具，并支持用户用 extra_tools 补充、exclude_tools 排除。
+- 提示词由插件端生成：先由插件调用 LLM 生成画面描述，再交给 Agent 据此调用生图
+  工具，而非让模型在工具循环里自行编写提示词。
 - 失败静默降级：任何环节出错都只记录日志、回退为纯文本，绝不把错误信息塞进
   发送给用户的消息内容。
 """
@@ -163,7 +164,9 @@ class ImageMixin:
         返回一个 ToolSet（可能为空）。
         """
         extra = set(self._parse_name_list((image_conf or {}).get("extra_tools", [])))
-        exclude = set(self._parse_name_list((image_conf or {}).get("exclude_tools", [])))
+        exclude = set(
+            self._parse_name_list((image_conf or {}).get("exclude_tools", []))
+        )
 
         try:
             all_tools = list(getattr(tool_manager, "func_list", []) or [])
@@ -183,7 +186,11 @@ class ImageMixin:
         # extra 里指向但上面没收进来的（理论上已收，双保险按名字补一次）
         for name in extra:
             if tool_set.get_tool(name) is None and name not in exclude:
-                t = tool_manager.get_func(name) if hasattr(tool_manager, "get_func") else None
+                t = (
+                    tool_manager.get_func(name)
+                    if hasattr(tool_manager, "get_func")
+                    else None
+                )
                 if t is not None:
                     tool_set.add_tool(t)
         return tool_set
@@ -191,21 +198,67 @@ class ImageMixin:
     # 生图相关关键词（小写）。命中工具名或描述即视为候选生图工具。
     # 视频类（video）刻意不收，避免把视频生成工具当配图。
     _IMAGE_KEYWORDS = (
-        "draw", "image", "paint", "pic", "photo", "illustr", "t2i", "text2image",
-        "text-to-image", "stable", "diffusion", "midjourney", "dalle", "dall-e",
-        "flux", "comfyui", "render",
-        "生图", "绘图", "绘画", "画图", "配图", "图片", "作画", "出图", "画一", "生成图",
+        "draw",
+        "image",
+        "paint",
+        "pic",
+        "photo",
+        "illustr",
+        "t2i",
+        "text2image",
+        "text-to-image",
+        "stable",
+        "diffusion",
+        "midjourney",
+        "dalle",
+        "dall-e",
+        "flux",
+        "comfyui",
+        "render",
+        "生图",
+        "绘图",
+        "绘画",
+        "画图",
+        "配图",
+        "图片",
+        "作画",
+        "出图",
+        "画一",
+        "生成图",
     )
     # 强生图信号：命中负向词后，只要工具名或描述里出现这些词，仍判定为生图工具。
     _IMAGE_STRONG = (
-        "draw", "paint", "t2i", "text2image", "text-to-image",
-        "generate image", "generate an image", "image generation",
-        "生图", "绘图", "绘画", "绘制", "画图", "作画", "配图",
-        "生成图片", "生成一张", "画一张", "画一幅",
+        "draw",
+        "paint",
+        "t2i",
+        "text2image",
+        "text-to-image",
+        "generate image",
+        "generate an image",
+        "image generation",
+        "生图",
+        "绘图",
+        "绘画",
+        "绘制",
+        "画图",
+        "作画",
+        "配图",
+        "生成图片",
+        "生成一张",
+        "画一张",
+        "画一幅",
     )
     # 明显非生图但可能含 image 字样的工具，关键词命中后再排除一层。
     _IMAGE_NEGATIVE = (
-        "read", "ocr", "recogn", "识别", "video", "视频", "understand", "analy", "描述图",
+        "read",
+        "ocr",
+        "recogn",
+        "识别",
+        "video",
+        "视频",
+        "understand",
+        "analy",
+        "描述图",
     )
 
     @classmethod

--- a/core/image_generator.py
+++ b/core/image_generator.py
@@ -25,7 +25,6 @@ from astrbot.api import logger
 try:
     from astrbot.core.agent.tool import ToolSet
     from astrbot.core.message.components import Image, Plain
-    from astrbot.core.message.message_event_result import MessageChain
     from astrbot.core.platform.astr_message_event import AstrMessageEvent
     from astrbot.core.platform.astrbot_message import AstrBotMessage, MessageMember
     from astrbot.core.platform.message_session import MessageSession
@@ -87,11 +86,22 @@ class _ImageCaptureEvent(_BaseEvent):  # type: ignore[misc, valid-type]
         # 收集被拦截的图片组件，供 Agent 结束后取用。
         self.captured_images: list["Image"] = []
 
-    async def send(self, message: "MessageChain") -> None:
-        """拦截发送：仅收集图片组件，不真正发往平台。"""
+    async def send(self, message: Any) -> None:
+        """拦截发送：仅收集图片组件，不真正发往平台。
+
+        兼容多种传入形式：MessageChain（含 .chain）、组件列表/元组、单个组件——
+        因为第三方生图插件调用 ``event.send`` 的写法不完全一致。
+        """
         try:
-            if message and getattr(message, "chain", None):
-                for comp in message.chain:
+            if message is not None:
+                chain = getattr(message, "chain", None)
+                if chain is not None:
+                    comps = chain
+                elif isinstance(message, (list, tuple)):
+                    comps = message
+                else:
+                    comps = [message]
+                for comp in comps:
                     if isinstance(comp, Image):
                         self.captured_images.append(comp)
         except Exception as e:  # noqa: BLE001 - 拦截阶段不应影响主流程
@@ -398,6 +408,9 @@ class ImageMixin:
 
         # 取已选定（并缓存）的生图工具名；未选定则尝试选一次。
         tool_manager = context.get_llm_tool_manager()
+        if not tool_manager:
+            logger.info("[主动消息] 未找到 LLM 工具管理器，跳过配图喵。")
+            return []
         tool_names = self._ensure_image_tool_names(tool_manager, image_conf)
         if not tool_names:
             # 已选不到（或已永久回退），_ensure_image_tool_names 内已记日志。
@@ -412,13 +425,6 @@ class ImageMixin:
         if tool_set.empty():
             logger.info("[主动消息] 已选定的生图工具当前不可用，跳过配图喵。")
             return []
-
-        capture_event = _ImageCaptureEvent(
-            context=context,
-            session=session,
-            message=text,
-            message_type=session.message_type,
-        )
 
         # 第一步：由插件端先生成“画面描述”（生图提示词）。
         # auto 模式下若模型判断这条消息不适合配图，会返回空，此时直接跳过。

--- a/core/image_generator.py
+++ b/core/image_generator.py
@@ -22,6 +22,7 @@ from typing import Any
 from astrbot.api import logger
 
 try:
+    from astrbot.core.agent.tool import ToolSet
     from astrbot.core.message.components import Image, Plain
     from astrbot.core.message.message_event_result import MessageChain
     from astrbot.core.platform.astr_message_event import AstrMessageEvent
@@ -143,6 +144,157 @@ class ImageMixin:
             logger.warning(f"[主动消息] 生成主动消息配图失败，将仅发送文本喵: {e!r}")
             return []
 
+    @staticmethod
+    def _parse_name_list(raw) -> list[str]:
+        """把配置值解析为名字列表。
+
+        兼容 list 与逗号/换行分隔的字符串两种写法，去重并保持顺序。
+        """
+        names: list[str] = []
+        if isinstance(raw, str):
+            for piece in raw.replace("\n", ",").split(","):
+                piece = piece.strip()
+                if piece:
+                    names.append(piece)
+        elif isinstance(raw, (list, tuple)):
+            for item in raw:
+                piece = str(item).strip()
+                if piece:
+                    names.append(piece)
+        seen: set[str] = set()
+        result: list[str] = []
+        for n in names:
+            if n not in seen:
+                seen.add(n)
+                result.append(n)
+        return result
+
+    def _select_image_tools(self, tool_manager, image_conf: dict):
+        """挑选交给 Agent 的生图工具。
+
+        规则：按关键词（工具名 + 描述）自动识别生图工具；再叠加用户配置的
+        extra_tools（强制补充，即使不含关键词）与 exclude_tools（强制排除）。
+        返回一个 ToolSet（可能为空）。
+        """
+        extra = set(self._parse_name_list((image_conf or {}).get("extra_tools", [])))
+        exclude = set(self._parse_name_list((image_conf or {}).get("exclude_tools", [])))
+
+        try:
+            all_tools = list(getattr(tool_manager, "func_list", []) or [])
+        except Exception:  # noqa: BLE001
+            all_tools = []
+
+        tool_set = ToolSet()
+        for tool in all_tools:
+            name = getattr(tool, "name", "") or ""
+            if name in exclude:
+                continue
+            desc = getattr(tool, "description", "") or ""
+            hit_keyword = self._looks_like_image_tool(name, desc)
+            if hit_keyword or name in extra:
+                tool_set.add_tool(tool)
+
+        # extra 里指向但上面没收进来的（理论上已收，双保险按名字补一次）
+        for name in extra:
+            if tool_set.get_tool(name) is None and name not in exclude:
+                t = tool_manager.get_func(name) if hasattr(tool_manager, "get_func") else None
+                if t is not None:
+                    tool_set.add_tool(t)
+        return tool_set
+
+    # 生图相关关键词（小写）。命中工具名或描述即视为候选生图工具。
+    # 视频类（video）刻意不收，避免把视频生成工具当配图。
+    _IMAGE_KEYWORDS = (
+        "draw", "image", "paint", "pic", "photo", "illustr", "t2i", "text2image",
+        "text-to-image", "stable", "diffusion", "midjourney", "dalle", "dall-e",
+        "flux", "comfyui", "render",
+        "生图", "绘图", "绘画", "画图", "配图", "图片", "作画", "出图", "画一", "生成图",
+    )
+    # 强生图信号：命中负向词后，只要工具名或描述里出现这些词，仍判定为生图工具。
+    _IMAGE_STRONG = (
+        "draw", "paint", "t2i", "text2image", "text-to-image",
+        "generate image", "generate an image", "image generation",
+        "生图", "绘图", "绘画", "绘制", "画图", "作画", "配图",
+        "生成图片", "生成一张", "画一张", "画一幅",
+    )
+    # 明显非生图但可能含 image 字样的工具，关键词命中后再排除一层。
+    _IMAGE_NEGATIVE = (
+        "read", "ocr", "recogn", "识别", "video", "视频", "understand", "analy", "描述图",
+    )
+
+    @classmethod
+    def _looks_like_image_tool(cls, name: str, description: str) -> bool:
+        """按关键词判断一个工具是否像“文生图”工具。
+
+        名字与描述双线匹配：任一命中生图关键词即为候选；命中负向词时，
+        只要名字或描述里仍出现强生图信号，依然保留。
+        """
+        haystack = f"{name} {description}".lower()
+        if not any(kw in haystack for kw in cls._IMAGE_KEYWORDS):
+            return False
+        # 命中负向词时，要求名字或描述里带强生图信号才保留，否则排除。
+        if any(neg in haystack for neg in cls._IMAGE_NEGATIVE):
+            return any(s in haystack for s in cls._IMAGE_STRONG)
+        return True
+
+    # 选不到生图工具的最大累计次数，超过则本次运行内永久回退为纯文本。
+    _IMAGE_TOOLS_MAX_ATTEMPTS = 3
+
+    def _ensure_image_tool_names(self, tool_manager, image_conf: dict) -> list[str]:
+        """返回已选定并缓存的生图工具名；未选定则尝试选一次。
+
+        - 一旦成功选定就缓存，后续直接复用，不再扫描。
+        - 累计选不到达到上限后永久回退（本次运行内不再尝试）。
+        """
+        if getattr(self, "_image_tools_disabled", False):
+            return []
+        if getattr(self, "_image_tools_selected", False):
+            return list(self._image_tools_cache)
+
+        tool_set = self._select_image_tools(tool_manager, image_conf)
+        names = [t.name for t in tool_set.tools] if tool_set else []
+        if names:
+            self._image_tools_cache = names
+            self._image_tools_selected = True
+            logger.info("[主动消息] 已找到可用的生图工具喵。")
+            return list(names)
+
+        # 没选到：累计计数，达到上限则永久回退。
+        self._image_tools_attempts = getattr(self, "_image_tools_attempts", 0) + 1
+        if self._image_tools_attempts >= self._IMAGE_TOOLS_MAX_ATTEMPTS:
+            self._image_tools_disabled = True
+            logger.info(
+                "[主动消息] 多次未找到可用生图工具喵，已回退为不生图模式（本次运行内不再尝试）。"
+            )
+        else:
+            logger.info("[主动消息] 暂未找到可用的生图工具喵，稍后重试。")
+        return []
+
+    async def prewarm_image_tools(self) -> None:
+        """插件加载/空闲时预选一次生图工具，避免发送时才扫描。
+
+        加载阶段生图插件可能尚未就绪，选不到属正常，不计入失败次数。
+        """
+        if not _IMAGE_AGENT_AVAILABLE:
+            return
+        if getattr(self, "_image_tools_selected", False) or getattr(
+            self, "_image_tools_disabled", False
+        ):
+            return
+        try:
+            tool_manager = self.context.get_llm_tool_manager()
+        except Exception:  # noqa: BLE001
+            return
+        # 预热用空配置即可（extra/exclude 在真正发送时按会话配置再算）；
+        # 这里只为尽早把“有没有生图工具”探明并缓存。
+        tool_set = self._select_image_tools(tool_manager, {})
+        names = [t.name for t in tool_set.tools] if tool_set else []
+        if names:
+            self._image_tools_cache = names
+            self._image_tools_selected = True
+            logger.info("[主动消息] 已找到可用的生图工具喵。")
+        # 预热选不到不记失败、不打 warning，留给发送时按需重试。
+
     async def _run_image_agent(
         self, session_id: str, text: str, image_conf: dict, mode: str
     ) -> list:
@@ -158,11 +310,21 @@ class ImageMixin:
             logger.info("[主动消息] 未找到可用对话 provider，跳过配图喵。")
             return []
 
-        # 汇集全部已注册的 LLM 工具（包含用户安装的任意生图插件的工具）。
+        # 取已选定（并缓存）的生图工具名；未选定则尝试选一次。
         tool_manager = context.get_llm_tool_manager()
-        tool_set = tool_manager.get_full_tool_set()
-        if tool_set is None or tool_set.empty():
-            logger.info("[主动消息] 未发现任何可用的 LLM 工具（如生图插件），跳过配图喵。")
+        tool_names = self._ensure_image_tool_names(tool_manager, image_conf)
+        if not tool_names:
+            # 已选不到（或已永久回退），_ensure_image_tool_names 内已记日志。
+            return []
+
+        # 用缓存的工具名重建本次调用的 ToolSet。
+        tool_set = ToolSet()
+        for name in tool_names:
+            tool = tool_manager.get_func(name)
+            if tool is not None:
+                tool_set.add_tool(tool)
+        if tool_set.empty():
+            logger.info("[主动消息] 已选定的生图工具当前不可用，跳过配图喵。")
             return []
 
         capture_event = _ImageCaptureEvent(

--- a/core/image_generator.py
+++ b/core/image_generator.py
@@ -1,0 +1,195 @@
+"""主动消息配图能力。
+
+通过 AstrBot 的工具循环 Agent，让主 LLM 在生成主动消息后自行判断/调用
+任意已安装的生图插件（向主 LLM 注册了工具的插件）来生成配图。生成的图片
+不会由生图插件直接发往平台，而是被一个“捕获型”合成事件拦截、收集后交还给
+本插件，统一走主动消息既有的发送流程（分段、装饰钩子、平台历史持久化）。
+
+设计要点：
+- provider 无关：不绑定任何特定生图插件，依赖 ``get_full_tool_set`` 暴露的
+  全部已注册工具，由模型自行选择。
+- 不改动 AstrBot 源码：仅继承公开基类、调用公开 API。
+- 失败静默降级：任何环节出错都只记录日志、回退为纯文本，绝不把错误信息塞进
+  发送给用户的消息内容。
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any
+
+from astrbot.api import logger
+
+try:
+    from astrbot.core.message.components import Image, Plain
+    from astrbot.core.message.message_event_result import MessageChain
+    from astrbot.core.platform.astr_message_event import AstrMessageEvent
+    from astrbot.core.platform.astrbot_message import AstrBotMessage, MessageMember
+    from astrbot.core.platform.message_session import MessageSession
+    from astrbot.core.platform.message_type import MessageType
+    from astrbot.core.platform.platform_metadata import PlatformMetadata
+
+    _IMAGE_AGENT_AVAILABLE = True
+except ImportError as _e:  # pragma: no cover - 取决于宿主版本
+    _IMAGE_AGENT_AVAILABLE = False
+    logger.warning(f"[主动消息] 当前 AstrBot 版本不支持配图 Agent 所需组件喵: {_e}")
+
+
+# 占位符，便于在依赖缺失时仍能定义类型注解。
+_BaseEvent = AstrMessageEvent if _IMAGE_AGENT_AVAILABLE else object
+
+
+class _ImageCaptureEvent(_BaseEvent):  # type: ignore[misc, valid-type]
+    """捕获型合成事件。
+
+    参考 AstrBot 官方的 ``CronMessageEvent`` 构造一个不绑定真实平台连接的合成
+    事件，供工具循环 Agent 使用。与之不同的是：本事件重写 ``send`` ，把生图
+    插件试图发送的图片 **拦截到内部缓冲区** ，而不是真正发往平台——从而让本
+    插件能拿回图片、自行决定如何发送。
+    """
+
+    def __init__(
+        self,
+        *,
+        context: Any,
+        session: "MessageSession",
+        message: str,
+        message_type: "MessageType",
+    ) -> None:
+        platform_meta = PlatformMetadata(
+            name="proactive_image",
+            description="ProactiveChat 配图合成事件",
+            id=session.platform_id,
+        )
+
+        msg_obj = AstrBotMessage()
+        msg_obj.type = message_type
+        msg_obj.self_id = "astrbot"
+        msg_obj.session_id = session.session_id
+        msg_obj.message_id = uuid.uuid4().hex
+        msg_obj.sender = MessageMember(user_id=session.session_id, nickname="主动消息")
+        msg_obj.message = [Plain(message)]
+        msg_obj.message_str = message
+        msg_obj.raw_message = message
+        msg_obj.timestamp = int(time.time())
+
+        super().__init__(message, msg_obj, platform_meta, session.session_id)
+
+        # 使用原始会话，保证工具内部读取 unified_msg_origin 等信息时一致。
+        self.session = session
+        self.context_obj = context
+        self.is_at_or_wake_command = True
+        self.is_wake = True
+
+        # 收集被拦截的图片组件，供 Agent 结束后取用。
+        self.captured_images: list["Image"] = []
+
+    async def send(self, message: "MessageChain") -> None:
+        """拦截发送：仅收集图片组件，不真正发往平台。"""
+        try:
+            if message and getattr(message, "chain", None):
+                for comp in message.chain:
+                    if isinstance(comp, Image):
+                        self.captured_images.append(comp)
+        except Exception as e:  # noqa: BLE001 - 拦截阶段不应影响主流程
+            logger.debug(f"[主动消息] 捕获配图组件时出现异常喵: {e!r}")
+        # 故意不调用 super().send()，避免触发真实平台发送与统计。
+
+    async def send_streaming(self, generator, use_fallback: bool = False) -> None:
+        async for chain in generator:
+            await self.send(chain)
+
+
+# 引导模型决定是否配图的系统提示。
+_AUTO_SYSTEM_PROMPT = (
+    "你刚刚生成了一条要主动发给用户的消息。现在请判断这条消息是否适合配一张图片。\n"
+    "- 如果适合（例如描述了某个画面、场景、物品、表情、心情且配图能增强表达），"
+    "请调用一个可用的生图工具来生成与消息内容相符的图片。\n"
+    "- 如果不适合（例如纯粹的问候、提问、抽象表达），则不要调用任何工具，直接结束。\n"
+    "不要输出多余的解释，只在需要时调用生图工具。"
+)
+_ALWAYS_SYSTEM_PROMPT = (
+    "你刚刚生成了一条要主动发给用户的消息。请调用一个可用的生图工具，生成一张"
+    "与这条消息内容相符的配图。请直接调用工具，不要输出多余解释。"
+)
+
+
+class ImageMixin:
+    """为主动消息提供“配图”能力的 Mixin。"""
+
+    async def _maybe_generate_proactive_images(
+        self, session_id: str, text: str, session_config: dict
+    ) -> list:
+        """根据配置决定并生成主动消息的配图。
+
+        返回一个图片组件列表（可能为空）。任何失败都会被吞掉并返回空列表，
+        以保证主动消息至少能以纯文本形式发出。
+        """
+        image_conf = (session_config or {}).get("image_settings", {})
+        mode = str(image_conf.get("mode", "off") or "off").strip().lower()
+        if mode not in ("auto", "always"):
+            return []
+
+        if not _IMAGE_AGENT_AVAILABLE:
+            logger.warning(
+                "[主动消息] 当前 AstrBot 版本不支持配图所需的合成事件组件，跳过配图喵。"
+            )
+            return []
+
+        try:
+            return await self._run_image_agent(session_id, text, image_conf, mode)
+        except Exception as e:  # noqa: BLE001 - 配图失败不可影响文本发送
+            logger.warning(f"[主动消息] 生成主动消息配图失败，将仅发送文本喵: {e!r}")
+            return []
+
+    async def _run_image_agent(
+        self, session_id: str, text: str, image_conf: dict, mode: str
+    ) -> list:
+        """用工具循环 Agent 驱动任意已注册的生图工具，收集其产出的图片。"""
+        context = self.context
+
+        # 解析会话来源，构造合成事件所需的 MessageSession。
+        session = MessageSession.from_str(session_id)
+
+        # 拿到当前会话使用的对话 provider；没有则无法驱动 Agent。
+        provider_id = await context.get_current_chat_provider_id(session_id)
+        if not provider_id:
+            logger.info("[主动消息] 未找到可用对话 provider，跳过配图喵。")
+            return []
+
+        # 汇集全部已注册的 LLM 工具（包含用户安装的任意生图插件的工具）。
+        tool_manager = context.get_llm_tool_manager()
+        tool_set = tool_manager.get_full_tool_set()
+        if tool_set is None or tool_set.empty():
+            logger.info("[主动消息] 未发现任何可用的 LLM 工具（如生图插件），跳过配图喵。")
+            return []
+
+        capture_event = _ImageCaptureEvent(
+            context=context,
+            session=session,
+            message=text,
+            message_type=session.message_type,
+        )
+
+        base_prompt = _ALWAYS_SYSTEM_PROMPT if mode == "always" else _AUTO_SYSTEM_PROMPT
+        extra = str(image_conf.get("extra_prompt", "") or "").strip()
+        system_prompt = f"{base_prompt}\n\n{extra}" if extra else base_prompt
+
+        user_prompt = f"这是要发送的主动消息内容：\n{text}"
+
+        await context.tool_loop_agent(
+            event=capture_event,
+            chat_provider_id=provider_id,
+            prompt=user_prompt,
+            tools=tool_set,
+            system_prompt=system_prompt,
+            max_steps=6,
+        )
+
+        images = list(capture_event.captured_images)
+        if images:
+            logger.info(f"[主动消息] 配图 Agent 共捕获 {len(images)} 张图片喵。")
+        else:
+            logger.info("[主动消息] 配图 Agent 未产出图片（模型判断无需配图或工具未生图）喵。")
+        return images

--- a/core/llm_adapter.py
+++ b/core/llm_adapter.py
@@ -48,6 +48,21 @@ class LlmMixin:
                 return False
         return default
 
+    @staticmethod
+    def _parse_persona_settings(persona_settings: Any) -> tuple[str, str, str]:
+        """解析人格配置，返回 (mode, persona_id, custom_persona)。
+
+        mode 规范化为 off/select/custom 之一；非法值按 off 处理。
+        """
+        if not isinstance(persona_settings, dict):
+            return "off", "", ""
+        mode = str(persona_settings.get("persona_mode", "off") or "off").strip().lower()
+        if mode not in {"off", "select", "custom"}:
+            mode = "off"
+        persona_id = str(persona_settings.get("persona_id", "") or "").strip()
+        custom_persona = str(persona_settings.get("custom_persona", "") or "").strip()
+        return mode, persona_id, custom_persona
+
     def _parse_bot_identifiers(self, value: Any) -> set[str]:
         normalized: set[str] = set()
         if isinstance(value, str):
@@ -610,9 +625,52 @@ class LlmMixin:
                 )
                 pure_history_messages = []
 
-            # 获取人格设定：优先会话 persona，再回退默认 persona
+            # 获取人格设定。
+            # 优先级：配置指定（select/custom，严格覆盖）→ 会话 persona → 默认 persona。
             original_system_prompt = ""
-            if conversation and conversation.persona_id:
+
+            persona_session_config = {}
+            get_session_config = getattr(self, "_get_session_config", None)
+            if callable(get_session_config):
+                try:
+                    persona_session_config = (
+                        get_session_config(effective_session_id) or {}
+                    )
+                except Exception:
+                    persona_session_config = {}
+            persona_settings = persona_session_config.get("persona_settings", {}) or {}
+            persona_mode, configured_persona_id, custom_persona = (
+                self._parse_persona_settings(persona_settings)
+            )
+
+            if persona_mode == "custom":
+                if custom_persona:
+                    original_system_prompt = custom_persona
+                    logger.info("[主动消息] 使用配置的自定义人格设定喵。")
+            elif persona_mode == "select":
+                if configured_persona_id:
+                    try:
+                        configured_persona = (
+                            self.context.persona_manager.get_persona_v3_by_id(
+                                configured_persona_id
+                            )
+                        )
+                    except Exception as e:
+                        configured_persona = None
+                        logger.warning(
+                            f"[主动消息] 读取配置人格 '{configured_persona_id}' 失败喵: {e}"
+                        )
+                    if configured_persona:
+                        original_system_prompt = configured_persona["prompt"]
+                        logger.info(
+                            f"[主动消息] 使用配置指定的人格: '{configured_persona_id}' 喵"
+                        )
+                    else:
+                        logger.warning(
+                            f"[主动消息] 配置指定的人格 '{configured_persona_id}' 未找到，回退为会话/默认人格喵。"
+                        )
+
+            if not original_system_prompt and conversation and conversation.persona_id:
                 persona = await self.context.persona_manager.get_persona(
                     conversation.persona_id
                 )
@@ -721,6 +779,52 @@ class LlmMixin:
         ).replace("{{current_time}}", now_str)
 
         logger.debug("[主动消息] 已生成包含动机和时间的 Prompt 喵。")
+
+        # 链式工具调用 / 模型自动回退（issue #56）：
+        # 仅在显式开启时改走工具循环 Agent；否则维持原有的单次生成路径，零回归。
+        agent_conf = session_config.get("agent_settings", {}) or {}
+        tool_mode = str(agent_conf.get("tool_mode", "off") or "off").strip().lower()
+        fallback_enabled = self._parse_bool_setting(
+            agent_conf.get("model_fallback_enable", False), default=False
+        )
+        run_agent = getattr(self, "_run_proactive_agent", None)
+        if (tool_mode in ("whitelist", "all") or fallback_enabled) and callable(
+            run_agent
+        ):
+            history_for_agent = self._sanitize_history_content(history_messages)
+            agent_text = await run_agent(
+                session_id,
+                final_user_simulation_prompt,
+                history_for_agent,
+                system_prompt,
+                agent_conf,
+            )
+            if agent_text:
+                if agent_text == "[object Object]":
+                    logger.error(
+                        "[主动消息] 喵呜！工具循环 Agent 返回了意料之外的 '[object Object]' 字符串喵！"
+                    )
+                    logger.warning("[主动消息] 已拦截本次发送喵。")
+                    return None, final_user_simulation_prompt
+                logger.info(
+                    f"[主动消息] 工具循环 Agent 已生成文本喵，长度: {len(agent_text)}。"
+                )
+                if self.telemetry and self.telemetry.enabled:
+                    # 记录 Agent 路径成功，便于与单次生成路径拆分分析。
+                    self._track_task(
+                        asyncio.create_task(
+                            self.telemetry.track_feature(
+                                "llm_generate_result",
+                                {
+                                    "provider_mode": "tool_loop_agent",
+                                    "success": True,
+                                    "history_count": len(history_for_agent),
+                                },
+                            )
+                        )
+                    )
+                return agent_text, final_user_simulation_prompt
+            logger.info("[主动消息] 工具循环 Agent 未产出可用文本，降级为单次生成喵。")
 
         llm_response_obj = None
         try:

--- a/core/message_sender.py
+++ b/core/message_sender.py
@@ -416,6 +416,20 @@ class SenderMixin:
         # 是否继续发送文本：未发出 TTS 或配置要求始终发文本
         should_send_text = not is_tts_sent or tts_conf.get("always_send_text", True)
 
+        # 配图：在发送文本之前先生成并发送图片（先图后文）。
+        # 生图是同步等待的，因此文本会等图片就绪后再发，不会出现“文本先到、图掉队”。
+        # 图片由本插件统一发送，走与文本相同的装饰钩子与平台历史持久化流程。
+        try:
+            images = await self._maybe_generate_proactive_images(
+                session_id, text, session_config
+            )
+            for image in images:
+                await self._send_chain_with_hooks(session_id, [image])
+                await asyncio.sleep(0.3)
+        except Exception as e:
+            # 配图属增强能力，任何异常都不应影响后续文本发送。
+            logger.warning(f"[主动消息] 发送主动消息配图时出现异常喵: {e!r}")
+
         if should_send_text:
             enable_seg = seg_conf.get("enable", False)
             threshold = seg_conf.get("words_count_threshold", 150)
@@ -488,19 +502,6 @@ class SenderMixin:
                             )
                         )
                     )
-
-        # 配图：根据会话配置决定是否生成并发送图片。
-        # 图片由本插件统一发送，走与文本相同的装饰钩子与平台历史持久化流程。
-        try:
-            images = await self._maybe_generate_proactive_images(
-                session_id, text, session_config
-            )
-            for image in images:
-                await self._send_chain_with_hooks(session_id, [image])
-                await asyncio.sleep(0.3)
-        except Exception as e:
-            # 配图属增强能力，任何异常都不应影响已发送的文本主流程。
-            logger.warning(f"[主动消息] 发送主动消息配图时出现异常喵: {e!r}")
 
         # Bot 在群聊发言后需要重置沉默计时
         if "group" in session_id.lower():

--- a/core/message_sender.py
+++ b/core/message_sender.py
@@ -489,6 +489,19 @@ class SenderMixin:
                         )
                     )
 
+        # 配图：根据会话配置决定是否生成并发送图片。
+        # 图片由本插件统一发送，走与文本相同的装饰钩子与平台历史持久化流程。
+        try:
+            images = await self._maybe_generate_proactive_images(
+                session_id, text, session_config
+            )
+            for image in images:
+                await self._send_chain_with_hooks(session_id, [image])
+                await asyncio.sleep(0.3)
+        except Exception as e:
+            # 配图属增强能力，任何异常都不应影响已发送的文本主流程。
+            logger.warning(f"[主动消息] 发送主动消息配图时出现异常喵: {e!r}")
+
         # Bot 在群聊发言后需要重置沉默计时
         if "group" in session_id.lower():
             await self._reset_group_silence_timer(session_id)

--- a/core/plugin_lifecycle.py
+++ b/core/plugin_lifecycle.py
@@ -162,7 +162,11 @@ class LifecycleMixin:
                     logger.debug(f"[主动消息] 预热配图工具时出现异常喵: {e!r}")
 
             try:
-                asyncio.create_task(_deferred_prewarm_image_tools())
+                # 用 _track_task 登记引用，避免后台任务在 sleep 期间被 GC 回收。
+                track = getattr(self, "_track_task", None)
+                task = asyncio.create_task(_deferred_prewarm_image_tools())
+                if callable(track):
+                    track(task)
             except Exception as e:  # noqa: BLE001
                 logger.debug(f"[主动消息] 启动配图工具预热任务失败喵: {e!r}")
 

--- a/core/plugin_lifecycle.py
+++ b/core/plugin_lifecycle.py
@@ -149,6 +149,22 @@ class LifecycleMixin:
                     )
                 )
 
+        # 预热配图工具：延迟少许，等其它生图插件也加载完成后再探测一次，
+        # 避免主动消息发送时才扫描工具。选不到不影响主流程。
+        prewarm = getattr(self, "prewarm_image_tools", None)
+        if callable(prewarm):
+            async def _deferred_prewarm_image_tools() -> None:
+                try:
+                    await asyncio.sleep(5)
+                    await prewarm()
+                except Exception as e:  # noqa: BLE001
+                    logger.debug(f"[主动消息] 预热配图工具时出现异常喵: {e!r}")
+
+            try:
+                asyncio.create_task(_deferred_prewarm_image_tools())
+            except Exception as e:  # noqa: BLE001
+                logger.debug(f"[主动消息] 启动配图工具预热任务失败喵: {e!r}")
+
     async def terminate(self) -> None:
         """插件被卸载或停用时调用的清理函数。"""
         logger.info("[主动消息] 收到插件终止指令，开始清理资源喵。")

--- a/core/plugin_lifecycle.py
+++ b/core/plugin_lifecycle.py
@@ -153,6 +153,7 @@ class LifecycleMixin:
         # 避免主动消息发送时才扫描工具。选不到不影响主流程。
         prewarm = getattr(self, "prewarm_image_tools", None)
         if callable(prewarm):
+
             async def _deferred_prewarm_image_tools() -> None:
                 try:
                     await asyncio.sleep(5)

--- a/main.py
+++ b/main.py
@@ -100,6 +100,11 @@ class ProactiveChatPlugin(
             str, dict
         ] = {}  # 临时态（如群聊最后用户发言时间）
         self.last_message_times: dict[str, float] = {}  # 会话最近消息时间，用于触发判断
+        # 配图工具选择缓存：避免每次发送都扫描全部工具。
+        self._image_tools_cache: list[str] = []  # 已选定的生图工具名
+        self._image_tools_selected: bool = False  # 是否已成功选定
+        self._image_tools_attempts: int = 0  # 累计选不到的次数
+        self._image_tools_disabled: bool = False  # 连续 3 次选不到后永久回退
         self.auto_trigger_timers: dict[
             str, asyncio.TimerHandle
         ] = {}  # 自动触发计时器句柄

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from astrbot.core.config.astrbot_config import AstrBotConfig
 from .core.chat_flow import ProactiveCoreMixin
 from .core.data_storage import StorageMixin
 from .core.llm_adapter import LlmMixin
+from .core.image_generator import ImageMixin
 from .core.message_events import EventsMixin
 from .core.message_sender import SenderMixin
 from .core.notification_center import NotificationCenter
@@ -38,6 +39,7 @@ class ProactiveChatPlugin(
     SchedulerMixin,  # 定时任务、自动触发与沉默计时
     LlmMixin,  # 上下文准备与 LLM 调用封装
     SenderMixin,  # 主动消息发送与装饰钩子
+    ImageMixin,  # 主动消息配图（工具循环 Agent 驱动任意生图插件）
     EventsMixin,  # 私聊/群聊事件监听处理
     LifecycleMixin,  # initialize/terminate 生命周期管理
     ProactiveCoreMixin,  # 主动消息主流程编排

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from astrbot.core.config.astrbot_config import AstrBotConfig
 from .core.chat_flow import ProactiveCoreMixin
 from .core.data_storage import StorageMixin
 from .core.llm_adapter import LlmMixin
+from .core.agent_runner import AgentRunnerMixin
 from .core.image_generator import ImageMixin
 from .core.message_events import EventsMixin
 from .core.message_sender import SenderMixin
@@ -38,6 +39,7 @@ class ProactiveChatPlugin(
     ConfigMixin,  # 配置读取与会话级配置路由
     SchedulerMixin,  # 定时任务、自动触发与沉默计时
     LlmMixin,  # 上下文准备与 LLM 调用封装
+    AgentRunnerMixin,  # 主动消息链式工具调用与模型自动回退（issue #56）
     SenderMixin,  # 主动消息发送与装饰钩子
     ImageMixin,  # 主动消息配图（工具循环 Agent 驱动任意生图插件）
     EventsMixin,  # 私聊/群聊事件监听处理


### PR DESCRIPTION
## 📝 描述 / Description

这个 PR 把主动消息的几项能力一起补上了（之前配图那个 PR 我关掉了，这次合到一起提）：

- 配图（#73）：让主动消息能带图发出。
- 链式工具调用、模型自动回退、人格自选（#56）：让主动消息能在发言前自己调工具收集信息、首选模型挂了能自动换备选、还能为主动消息单独指定人格。

底层都是基于本体的 `tool_loop_agent` 和同一个合成事件实现的，所以顺手把配图和正文这两套工具循环的合成事件统一成了一个，去掉了重复。

所有新功能默认都是关的，不开的话行为和旧版完全一样。

Closes #56
Closes #73

## 🛠️ 改动点 / Modifications

新增 `core/agent_runner.py`：

- `ProactiveAgentEvent`：统一的合成事件，既能捕获生图工具发出的图片，又会吞掉其余发送（正文只取模型最终输出）。配图模块也改用它，删掉了原来 `image_generator.py` 里那个几乎一模一样的 `_ImageCaptureEvent`。
- 链式工具调用：按 `tool_mode`（off / whitelist / all）选工具交给工具循环，`max_steps=0` 时按工具数自动推导上限。
- 模型回退：解析备选 provider 列表传给本体的 `fallback_providers`，本地留空时回退读全局 `fallback_chat_models`，跟本体行为对齐。

`core/llm_adapter.py`：

- 人格解析改成三级优先——配置指定（select/custom）严格覆盖 → 会话人格 → 默认人格。
- `_generate_llm_response` 在开启工具/回退时改走工具循环 Agent，失败则降级回原来的单次生成。

`_conf_schema.json`：私聊/群聊各加了 `agent_settings`（工具调用 + 回退）和 `persona_settings`（人格），用的都是本体原生控件（下拉、滑块、`select_providers` 多选、`select_persona`、`condition` 联动隐藏）。

`main.py`：接入新的 mixin。

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.

## 📸 运行截图或测试结果 / Screenshots or Test Results

离线单测 16 项全过（工具选择、回退解析、max_steps、人格解析等纯逻辑），`ruff check` + `ruff format` + JSON 校验都过。

另外在真实 AstrBot 4.25.1 + 真实模型下做了一轮端到端测试，核心 8/8 通过。关键日志摘录：

**链式工具调用真触发**（whitelist 选中 `uapi_weather`，模型据工具结果生成）：

```
[INFO] [runners.tool_loop_agent_runner]: Agent 使用工具: ['uapi_weather']
[INFO] [runners.tool_loop_agent_runner]: 使用工具：uapi_weather，参数：{'city': '北京'}
[PASS] G2_链式工具端到端 :: '抱歉，目前天气查询服务暂时不可用……建议您打开手机天气 App 查看最新情况'
```

**模型回退真触发**（坏 key 首选失败 → 本体接管 → 切备选成功）：

```
当前会话 provider_id: bad/primary
[WARN] [runners.tool_loop_agent_runner:555]: Chat Model bad/primary request error
[PASS] F_回退真触发(坏首选→deepseek) :: '你好！有什么可以帮你的吗？'
```

**配图捕获**（统一合成事件捕获生图工具发出的图片）：

```
[INFO] [runners.tool_loop_agent_runner]: Agent 使用工具: ['draw_image']
[INFO] [fake_drawer.main]: [FakeDrawer] draw_image 被调用，发送内联图片。
[PASS] H_配图捕获Image :: 捕获图片数=1
```

完整 8 项：插件加载无报错、纯 Agent 生成出文本、模型回退、链式工具调用、配图捕获、人格自选解析、max_steps 推导，全部 ✅。

回退用临时构造的坏 key provider 作首选验证；链式工具用 UApiPro 工具箱的 `uapi_weather` 验证；配图用一个只注册生图工具的本地测试插件验证“工具 → 合成事件捕获图片”这条链路。

## ✅ 检查清单 / Checklist

<!--如果分支被合并，您的代码将成为本插件的一部分！在提交前，请核查以下几点内容。-->
<!--If merged, your code will be part of this plugin! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_proactive_chat/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_proactive_chat/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

为基于工具循环（tool-loop）的文本生成、模型回退、人格（persona）选择和自动图像生成添加主动消息支持，同时在默认情况下保持行为不变。

新功能：
- 使主动消息在配置后可以使用 AstrBot 的工具循环代理（tool loop agent）进行链式工具调用，并在需要时自动进行模型回退。
- 允许主动消息使用可配置的人格，并提供显式的覆盖模式，包括自定义提示词（custom prompts）。
- 为主动消息添加通过图像工具进行的主动图像生成支持，包括自动/始终模式，以及基于关键词的工具选择，并支持按会话进行配置。

增强：
- 引入统一的合成事件，用于主动工具循环运行，能够捕获图像并抑制中间发送，供文本和图像流程共享。
- 对可用图像工具的发现过程进行缓存和预热，以降低开销并避免重复的失败扫描。

测试：
- 利用现有的遥测和配置管道，使工具循环和回退的使用情况可以被单独跟踪，而无需更改默认行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add proactive message support for tool-loop based text generation, model fallback, persona selection, and automatic image generation while keeping behavior unchanged by default.

New Features:
- Enable proactive messages to use AstrBot's tool loop agent for chained tool calls and automatic model fallback when configured.
- Allow proactive messages to use configurable personas with explicit override modes including custom prompts.
- Add proactive image generation for proactive messages via image tools, including auto/always modes and tool selection based on keywords with per-session configuration.

Enhancements:
- Introduce a unified synthetic event for proactive tool-loop runs that captures images and suppresses intermediate sends, shared by text and image flows.
- Cache and prewarm discovery of available image tools to reduce overhead and avoid repeated failed scans.

Tests:
- Leverage existing telemetry and configuration plumbing so tool-loop and fallback usage can be tracked separately without changing default behavior.

</details>